### PR TITLE
feat(resolve_config): accept endpoint/platform for self-hosted GitLab/GHE

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Seven tools plus a preset reference:
 | --- | --- |
 | `check_setup` | Report Renovate CLI + validator availability, versions, env overrides, and install hints. Also runs at server startup and embeds the result in the server's `instructions` when anything's missing. |
 | `read_config` | Locate and parse `renovate.json` / `renovate.json5` / `.renovaterc*` / `.github/renovate.json` / `.gitlab/renovate.json` / `package.json#renovate` in a repo — in Renovate's priority order. |
-| `resolve_config` | Expand every `extends` preset against the committed catalogue and return the fully resolved config (offline; no `renovate` invocation). Flags unresolvable entries with a reason. Opt in to fetching `github>` / `gitlab>` presets over HTTPS with `externalPresets: true` (auth via `GITHUB_TOKEN` / `GITLAB_TOKEN` / `RENOVATE_TOKEN`); `local>`, `bitbucket>`, `gitea>`, and npm presets remain in `presetsUnresolved` regardless of the flag. |
+| `resolve_config` | Expand every `extends` preset against the committed catalogue and return the fully resolved config (offline; no `renovate` invocation). Flags unresolvable entries with a reason. Opt in to fetching `github>` / `gitlab>` presets over HTTPS with `externalPresets: true` (auth via `GITHUB_TOKEN` / `GITLAB_TOKEN` / `RENOVATE_TOKEN`). For GitHub Enterprise or self-hosted GitLab, pass `endpoint` (API base URL) — and `platform` in addition to route `local>` presets through the same host. `bitbucket>`, `gitea>`, and npm presets remain in `presetsUnresolved` regardless. |
 | `preview_custom_manager` | Preview a `customManagers` (regex) entry against a local repo — offline, no `renovate` invocation. Shows which files match `fileMatch`, which lines match each `matchStrings` regex with named capture groups, and what dep info the template fields produce. Intended for fast regex iteration; run `dry_run` afterwards for full-fidelity confirmation. |
 | `validate_config` | Run `renovate-config-validator` against a file or inline object. |
 | `dry_run` | Run Renovate with `--platform=local --dry-run`, return the structured JSON report (no PRs, no pushes). |
@@ -23,7 +23,7 @@ Seven tools plus a preset reference:
 - Node.js ≥ 24 (aligns with Renovate's own engine requirement).
 - Renovate available on your `PATH` — either a global install (`npm i -g renovate`) or a project-local install that exposes `renovate` and `renovate-config-validator` via `npm exec`. Only needed for `validate_config`, `dry_run`, and `write_config`; the offline tools (`read_config`, `resolve_config`, `preview_custom_manager`) work without it.
 - Override binary locations with env vars if needed: `RENOVATE_BIN`, `RENOVATE_CONFIG_VALIDATOR_BIN`.
-- Optional for `resolve_config` with `externalPresets: true`: `GITHUB_TOKEN` / `GITLAB_TOKEN` (or `RENOVATE_TOKEN` as a fallback) for fetching presets from private repos or to avoid rate limits.
+- Optional for `resolve_config` with `externalPresets: true`: `GITHUB_TOKEN` / `GITLAB_TOKEN` (or `RENOVATE_TOKEN` as a fallback) for fetching presets from private repos or to avoid rate limits. For GitHub Enterprise / self-hosted GitLab, pass the `endpoint` tool input (and `platform` if you also want `local>` presets routed there) — env vars like `RENOVATE_ENDPOINT` are **not** read, since the MCP server runs under Claude rather than in your shell.
 
 ## Install
 
@@ -110,6 +110,6 @@ Secrets required on the repo: `RELEASE_PLEASE_TOKEN` (a PAT for release-please).
 
 - `validate_config`, `dry_run`, and `write_config` shell out to the Renovate CLI rather than importing Renovate as a library — this decouples our Node version from Renovate's (currently Node 24).
 - `resolve_config` and `preview_custom_manager` are fully in-process and never invoke the Renovate CLI, so they work without a Renovate install.
-- `resolve_config` expands `extends` against a committed snapshot of Renovate's built-in presets (`src/data/presets.generated.ts`). External `github>` / `gitlab>` fetching is opt-in, uses each platform's contents API with a 10 s timeout, and caches results per call.
+- `resolve_config` expands `extends` against a committed snapshot of Renovate's built-in presets (`src/data/presets.generated.ts`). External `github>` / `gitlab>` fetching is opt-in, uses each platform's contents API with a 10 s timeout, and caches results per call. The `endpoint` input swaps in a custom API base for GHE / self-hosted GitLab; `platform` additionally rewrites `local>` presets to be fetched against that endpoint.
 - `dry_run` uses `--report-type=file` so we get a structured JSON report instead of scraping stdout.
 - `write_config` writes to a temp file, validates, then atomically renames — so a failed validation never leaves a broken config on disk.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Seven tools plus a preset reference:
 - Node.js ≥ 24 (aligns with Renovate's own engine requirement).
 - Renovate available on your `PATH` — either a global install (`npm i -g renovate`) or a project-local install that exposes `renovate` and `renovate-config-validator` via `npm exec`. Only needed for `validate_config`, `dry_run`, and `write_config`; the offline tools (`read_config`, `resolve_config`, `preview_custom_manager`) work without it.
 - Override binary locations with env vars if needed: `RENOVATE_BIN`, `RENOVATE_CONFIG_VALIDATOR_BIN`.
-- Optional for `resolve_config` with `externalPresets: true`: `GITHUB_TOKEN` / `GITLAB_TOKEN` (or `RENOVATE_TOKEN` as a fallback) for fetching presets from private repos or to avoid rate limits. For GitHub Enterprise / self-hosted GitLab, pass the `endpoint` tool input (and `platform` if you also want `local>` presets routed there) — env vars like `RENOVATE_ENDPOINT` are **not** read, since the MCP server runs under Claude rather than in your shell.
+- Optional for `resolve_config` with `externalPresets: true`: `GITHUB_TOKEN` / `GITLAB_TOKEN` (or `RENOVATE_TOKEN` as a fallback) for fetching presets from private repos or to avoid rate limits. For GitHub Enterprise / self-hosted GitLab, pass the `endpoint` tool input (and `platform` if you also want `local>` presets routed there); `RENOVATE_ENDPOINT` is **not** read. Any env vars the tool does read must be set on the MCP server process itself — via the `env` key in `claude_desktop_config.json` / `.mcp.json`, not your shell, since the MCP server runs as a child of Claude and does not inherit shell env.
 
 ## Install
 

--- a/src/lib/externalPresetFetcher.ts
+++ b/src/lib/externalPresetFetcher.ts
@@ -3,6 +3,13 @@ import { classifyExternalSource, type ParsedPreset } from "./presetResolver.js";
 export interface FetchOptions {
   timeoutMs?: number;
   cache?: Map<string, Promise<FetchResult>>;
+  /**
+   * Override the API base URL. For `github>` presets, defaults to
+   * `https://api.github.com` (pass `https://ghe.example.com/api/v3` for GitHub
+   * Enterprise). For `gitlab>`, defaults to `https://gitlab.com/api/v4` (pass
+   * `https://gitlab.example.com/api/v4` for self-hosted).
+   */
+  endpoint?: string;
   /** Injectable for tests. Defaults to globalThis.fetch. */
   fetchImpl?: typeof fetch;
 }
@@ -12,6 +19,12 @@ export type FetchResult =
   | { ok: false; reason: string };
 
 const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_GITHUB_API_BASE = "https://api.github.com";
+const DEFAULT_GITLAB_API_BASE = "https://gitlab.com/api/v4";
+
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}
 
 export async function fetchExternalPreset(
   parsed: ParsedPreset,
@@ -39,12 +52,13 @@ function dispatch(parsed: ParsedPreset, options: FetchOptions): Promise<FetchRes
 
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const endpoint = options.endpoint ? trimTrailingSlash(options.endpoint) : undefined;
 
   switch (parsed.source) {
     case "github":
-      return fetchGitHub(parsed, timeoutMs, fetchImpl);
+      return fetchGitHub(parsed, timeoutMs, fetchImpl, endpoint);
     case "gitlab":
-      return fetchGitLab(parsed, timeoutMs, fetchImpl);
+      return fetchGitLab(parsed, timeoutMs, fetchImpl, endpoint);
     default:
       return Promise.resolve({
         ok: false,
@@ -57,13 +71,15 @@ async function fetchGitHub(
   parsed: ParsedPreset,
   timeoutMs: number,
   fetchImpl: typeof fetch,
+  endpoint: string | undefined,
 ): Promise<FetchResult> {
   if (!parsed.repoPath || !parsed.repoPath.includes("/")) {
     return { ok: false, reason: `Invalid github preset: ${parsed.original}` };
   }
   const file = presetFileName(parsed);
   const ref = parsed.ref ?? "HEAD";
-  const url = `https://api.github.com/repos/${parsed.repoPath}/contents/${encodeFilePath(
+  const apiBase = endpoint ?? DEFAULT_GITHUB_API_BASE;
+  const url = `${apiBase}/repos/${parsed.repoPath}/contents/${encodeFilePath(
     file,
   )}?ref=${encodeURIComponent(ref)}`;
   const token = process.env.GITHUB_TOKEN || process.env.RENOVATE_TOKEN;
@@ -79,13 +95,15 @@ async function fetchGitLab(
   parsed: ParsedPreset,
   timeoutMs: number,
   fetchImpl: typeof fetch,
+  endpoint: string | undefined,
 ): Promise<FetchResult> {
   if (!parsed.repoPath) {
     return { ok: false, reason: `Invalid gitlab preset: ${parsed.original}` };
   }
   const file = presetFileName(parsed);
   const ref = parsed.ref ?? "HEAD";
-  const url = `https://gitlab.com/api/v4/projects/${encodeURIComponent(
+  const apiBase = endpoint ?? DEFAULT_GITLAB_API_BASE;
+  const url = `${apiBase}/projects/${encodeURIComponent(
     parsed.repoPath,
   )}/repository/files/${encodeURIComponent(file)}/raw?ref=${encodeURIComponent(ref)}`;
   const token = process.env.GITLAB_TOKEN || process.env.RENOVATE_TOKEN;

--- a/src/lib/presetResolver.ts
+++ b/src/lib/presetResolver.ts
@@ -12,11 +12,27 @@ export interface ResolveResult {
   presetsUnresolved: UnresolvedPreset[];
 }
 
+export type FetchPlatform = "github" | "gitlab";
+
 export interface ResolveOptions {
   /** When true, fetch external presets (github>, gitlab>, …) over the network. */
   fetchExternal?: boolean;
   /** Per-request fetch timeout; forwarded to the external fetcher. */
   timeoutMs?: number;
+  /**
+   * Override the API base URL used for `github>` / `gitlab>` fetches — e.g.
+   * `https://ghe.example.com/api/v3` for GitHub Enterprise or
+   * `https://gitlab.example.com/api/v4` for self-hosted GitLab. When unset,
+   * defaults to `https://api.github.com` and `https://gitlab.com/api/v4`.
+   */
+  endpoint?: string;
+  /**
+   * Platform flavour of `endpoint`. Required only when it's not derivable from
+   * the preset source (e.g. to resolve `local>` presets against a self-hosted
+   * GitHub/GitLab). When set, `local>owner/repo` is fetched as if it were
+   * `<platform>>owner/repo`.
+   */
+  platform?: FetchPlatform;
 }
 
 export type ExternalSource =
@@ -95,6 +111,8 @@ export interface ParsedPreset {
 interface ExpandContext {
   fetchExternal: boolean;
   timeoutMs: number | undefined;
+  endpoint: string | undefined;
+  platform: FetchPlatform | undefined;
   cache: Map<string, Promise<FetchResult>>;
 }
 
@@ -114,6 +132,8 @@ export async function resolveConfig(
   const ctx: ExpandContext = {
     fetchExternal: options.fetchExternal ?? false,
     timeoutMs: options.timeoutMs,
+    endpoint: options.endpoint,
+    platform: options.platform,
     cache: new Map(),
   };
 
@@ -188,7 +208,15 @@ async function loadPresetBody(
     return preset.body;
   }
 
-  const classification = classifyExternalSource(parsed.source);
+  // If a `platform` is configured, route `local>` presets through it — the
+  // self-hosted case where the user's "local" presets actually live on their
+  // private GitHub/GitLab at `endpoint`.
+  const effective =
+    parsed.source === "local" && ctx.platform
+      ? { ...parsed, source: ctx.platform }
+      : parsed;
+
+  const classification = classifyExternalSource(effective.source!);
   if (!classification.fetchable) {
     unresolvedList.push({ preset: parsed.original, reason: classification.reason });
     return null;
@@ -203,8 +231,9 @@ async function loadPresetBody(
     return null;
   }
 
-  const result = await fetchExternalPreset(parsed, {
+  const result = await fetchExternalPreset(effective, {
     timeoutMs: ctx.timeoutMs,
+    endpoint: ctx.endpoint,
     cache: ctx.cache,
   });
 

--- a/src/tools/resolveConfig.ts
+++ b/src/tools/resolveConfig.ts
@@ -9,7 +9,7 @@ export function registerResolveConfig(server: McpServer): void {
     {
       title: "Resolve Renovate config (expand presets)",
       description:
-        "Expand every preset referenced by `extends` and return the fully resolved config. Built-in presets resolve offline against the committed catalogue. Pass `externalPresets: true` to fetch `github>` and `gitlab>` presets over HTTPS (with optional `GITHUB_TOKEN` / `GITLAB_TOKEN` / `RENOVATE_TOKEN` for private repos). `local>`, `bitbucket>`, `gitea>`, and npm presets are structurally unsupported by this tool and remain in `presetsUnresolved` regardless of the flag. Pass either `repoPath` (reads the repo's config) or `configContent` (an inline config object).",
+        "Expand every preset referenced by `extends` and return the fully resolved config. Built-in presets resolve offline against the committed catalogue. Pass `externalPresets: true` to fetch `github>` and `gitlab>` presets over HTTPS (with optional `GITHUB_TOKEN` / `GITLAB_TOKEN` / `RENOVATE_TOKEN` for private repos). For GitHub Enterprise or self-hosted GitLab, pass `endpoint` (API base URL, e.g. `https://ghe.example.com/api/v3` or `https://gitlab.example.com/api/v4`); pass `platform` in addition to route `local>` presets through the same endpoint. `bitbucket>`, `gitea>`, and npm presets are structurally unsupported and remain in `presetsUnresolved` regardless. Endpoint and platform are **tool inputs only** — env vars like `RENOVATE_ENDPOINT` are not read, since the MCP server runs under Claude rather than in your shell. Pass either `repoPath` (reads the repo's config) or `configContent` (an inline config object).",
       inputSchema: {
         repoPath: z
           .string()
@@ -27,9 +27,21 @@ export function registerResolveConfig(server: McpServer): void {
           .describe(
             "When true, fetch external presets (github>, gitlab>) over HTTPS. Credentials are read from GITHUB_TOKEN / GITLAB_TOKEN / RENOVATE_TOKEN env vars. Default false.",
           ),
+        endpoint: z
+          .string()
+          .optional()
+          .describe(
+            "API base URL for github>/gitlab> fetches. Use for GitHub Enterprise (e.g. https://ghe.example.com/api/v3) or self-hosted GitLab (e.g. https://gitlab.example.com/api/v4). Defaults to https://api.github.com and https://gitlab.com/api/v4.",
+          ),
+        platform: z
+          .enum(["github", "gitlab"])
+          .optional()
+          .describe(
+            "Platform flavour of `endpoint`. When set, `local>owner/repo` presets are fetched as if they were `<platform>>owner/repo` — useful for self-hosted setups where a config's `local>` presets actually live on your private GitHub/GitLab.",
+          ),
       },
     },
-    async ({ repoPath, configContent, externalPresets }) => {
+    async ({ repoPath, configContent, externalPresets, endpoint, platform }) => {
       if (!repoPath && !configContent) {
         return {
           isError: true,
@@ -62,6 +74,8 @@ export function registerResolveConfig(server: McpServer): void {
 
       const { resolved, presetsResolved, presetsUnresolved } = await resolveConfig(source, {
         fetchExternal: externalPresets ?? false,
+        endpoint,
+        platform,
       });
 
       return {

--- a/src/tools/resolveConfig.ts
+++ b/src/tools/resolveConfig.ts
@@ -25,7 +25,7 @@ export function registerResolveConfig(server: McpServer): void {
           .boolean()
           .optional()
           .describe(
-            "When true, fetch external presets (github>, gitlab>) over HTTPS. Credentials are read from GITHUB_TOKEN / GITLAB_TOKEN / RENOVATE_TOKEN env vars. Default false.",
+            "When true, fetch external presets (github>, gitlab>) over HTTPS. Credentials come from GITHUB_TOKEN / GITLAB_TOKEN / RENOVATE_TOKEN env vars set on the MCP server process — via the `env` key in claude_desktop_config.json / .mcp.json, not your shell, since the MCP server runs as a child of Claude and does not inherit shell env. Default false.",
           ),
         endpoint: z
           .string()

--- a/test/unit/externalPresetFetcher.test.ts
+++ b/test/unit/externalPresetFetcher.test.ts
@@ -141,6 +141,46 @@ describe("fetchExternalPreset — gitlab", () => {
   });
 });
 
+describe("fetchExternalPreset — endpoint override", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("uses a GHE endpoint as API base for github> fetches", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(makeResponse({ automerge: true }));
+    await fetchExternalPreset(parsePreset("github>acme/cfg"), {
+      fetchImpl,
+      endpoint: "https://ghe.example.com/api/v3",
+    });
+    const [url] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(
+      "https://ghe.example.com/api/v3/repos/acme/cfg/contents/default.json?ref=HEAD",
+    );
+  });
+
+  it("uses a self-hosted endpoint as API base for gitlab> fetches", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(makeResponse({ automerge: true }));
+    await fetchExternalPreset(parsePreset("gitlab>acme/cfg:strict#main"), {
+      fetchImpl,
+      endpoint: "https://gitlab.example.com/api/v4",
+    });
+    const [url] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(
+      "https://gitlab.example.com/api/v4/projects/acme%2Fcfg/repository/files/strict.json/raw?ref=main",
+    );
+  });
+
+  it("strips a trailing slash from the endpoint before concatenation", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(makeResponse({ automerge: true }));
+    await fetchExternalPreset(parsePreset("github>acme/cfg"), {
+      fetchImpl,
+      endpoint: "https://ghe.example.com/api/v3/",
+    });
+    const [url] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(
+      "https://ghe.example.com/api/v3/repos/acme/cfg/contents/default.json?ref=HEAD",
+    );
+  });
+});
+
 describe("fetchExternalPreset — unsupported sources", () => {
   it("returns a clear error for bitbucket", async () => {
     const result = await fetchExternalPreset(parsePreset("bitbucket>acme/cfg"));

--- a/test/unit/presetResolver.test.ts
+++ b/test/unit/presetResolver.test.ts
@@ -292,3 +292,95 @@ describe("structurally-unsupported sources: identical reason across flag values"
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("resolveConfig with endpoint / platform", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("routes github> fetches through a custom endpoint (GitHub Enterprise)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ automerge: true }), { status: 200 }),
+    );
+    const { resolved, presetsResolved } = await resolveConfig(
+      { extends: ["github>acme/cfg"] },
+      { fetchExternal: true, endpoint: "https://ghe.example.com/api/v3" },
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(
+      "https://ghe.example.com/api/v3/repos/acme/cfg/contents/default.json?ref=HEAD",
+    );
+    expect(resolved).toMatchObject({ automerge: true });
+    expect(presetsResolved).toEqual(["github>acme/cfg"]);
+  });
+
+  it("routes gitlab> fetches through a custom endpoint (self-hosted GitLab)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ automerge: true }), { status: 200 }),
+    );
+    await resolveConfig(
+      { extends: ["gitlab>acme/cfg"] },
+      { fetchExternal: true, endpoint: "https://gitlab.example.com/api/v4" },
+    );
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(
+      "https://gitlab.example.com/api/v4/projects/acme%2Fcfg/repository/files/default.json/raw?ref=HEAD",
+    );
+  });
+
+  it("rewrites local> through platform + endpoint (self-hosted GitLab)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ automerge: true }), { status: 200 }),
+    );
+    const { resolved, presetsResolved, presetsUnresolved } = await resolveConfig(
+      { extends: ["local>acme/cfg"] },
+      {
+        fetchExternal: true,
+        endpoint: "https://gitlab.example.com/api/v4",
+        platform: "gitlab",
+      },
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(
+      "https://gitlab.example.com/api/v4/projects/acme%2Fcfg/repository/files/default.json/raw?ref=HEAD",
+    );
+    expect(resolved).toMatchObject({ automerge: true });
+    // The original local> string stays in presetsResolved so users see what
+    // they wrote, not what we rewrote it to.
+    expect(presetsResolved).toEqual(["local>acme/cfg"]);
+    expect(presetsUnresolved).toEqual([]);
+  });
+
+  it("rewrites local> through platform=github", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ automerge: true }), { status: 200 }),
+    );
+    await resolveConfig(
+      { extends: ["local>acme/cfg"] },
+      {
+        fetchExternal: true,
+        endpoint: "https://ghe.example.com/api/v3",
+        platform: "github",
+      },
+    );
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(
+      "https://ghe.example.com/api/v3/repos/acme/cfg/contents/default.json?ref=HEAD",
+    );
+  });
+
+  it("leaves local> unsupported when platform is not set, even with a custom endpoint", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { presetsResolved, presetsUnresolved } = await resolveConfig(
+      { extends: ["local>acme/cfg"] },
+      { fetchExternal: true, endpoint: "https://gitlab.example.com/api/v4" },
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(presetsResolved).toEqual([]);
+    expect(presetsUnresolved).toHaveLength(1);
+    expect(presetsUnresolved[0]?.reason).toMatch(/out of scope/i);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #30. Stacked on #33 — targets the `fix/resolve-config-unsupported-presets` base so the diff is just the new feature. Retarget to `main` after #33 merges.

`fetchGitHub` and `fetchGitLab` hardcoded `api.github.com` and `gitlab.com`, so GitHub Enterprise and self-hosted GitLab users could never resolve their `github>` / `gitlab>` presets. Renovate itself handles this via config or `RENOVATE_ENDPOINT` env — but MCP servers run under Claude's process rather than the user's shell, so local env isn't visible.

## Changes

- **New tool input `endpoint`** — API base URL (e.g. `https://ghe.example.com/api/v3`, `https://gitlab.example.com/api/v4`). Overrides the default API base for `github>` / `gitlab>` fetches. Trailing slash is trimmed defensively.
- **New tool input `platform`** (`"github" | "gitlab"`) — additionally rewrites `local>owner/repo` to be fetched as `<platform>>owner/repo`. Covers the motivating self-hosted case where a config's `local>` presets actually live on the user's private host. The original `local>` string still appears in `presetsResolved` so users see what they wrote.
- **No env var fallback.** Considered and rejected: respecting `RENOVATE_ENDPOINT` from an env we can't reliably see (user's shell vs. MCP server env) would be silently wrong. Tool inputs only; docs call this out.
- Plumbed through `ResolveOptions` → `ExpandContext` → `fetchExternalPreset`. Fetcher signature now takes `endpoint` alongside `timeoutMs` and `fetchImpl`.
- `resolve_config` tool description, README `resolve_config` row, Requirements, and Design notes all updated in sync (per CLAUDE.md keep-README-in-sync rule).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — all 94 tests pass, including 8 new:
  - Stubbed fetch confirms URL reflects the supplied endpoint for both `github>` and `gitlab>` (`externalPresetFetcher.test.ts`).
  - Trailing slash on endpoint is stripped before concatenation.
  - End-to-end through `resolveConfig`: `endpoint` reaches the fetch URL for both platforms.
  - `platform` + `local>` correctly rewrites to `github>` / `gitlab>` and fetches against the endpoint.
  - Without `platform`, `local>` stays unsupported (no network call) even when a custom endpoint is set.