### PR TITLE
feat(preview_custom_manager): honor .gitignore when walking the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Secrets required on the repo: `RELEASE_PLEASE_TOKEN` (a PAT for release-please).
 
 - `validate_config`, `dry_run`, and `write_config` shell out to the Renovate CLI rather than importing Renovate as a library — this decouples our Node version from Renovate's (currently Node 24).
 - `resolve_config` and `preview_custom_manager` are fully in-process and never invoke the Renovate CLI, so they work without a Renovate install.
+- `preview_custom_manager` honors `.gitignore` (including nested `.gitignore`s and `.git/info/exclude`) when walking the repo, so generated/vendored directories like `dist/`, `.next/`, `target/`, `__pycache__/` don't crowd out real hits against the `maxFilesScanned` cap. `node_modules/` and `.git/` are always skipped as a safety net even when no `.gitignore` is present.
 - `resolve_config` expands `extends` against a committed snapshot of Renovate's built-in presets (`src/data/presets.generated.ts`). External `github>` / `gitlab>` fetching is opt-in, uses each platform's contents API with a 10 s timeout, and caches results per call. The `endpoint` input swaps in a custom API base for GHE / self-hosted GitLab; `platform` additionally rewrites `local>` presets to be fetched against that endpoint.
 - `dry_run` uses `--report-type=file` so we get a structured JSON report instead of scraping stdout.
 - `write_config` writes to a temp file, validates, then atomically renames — so a failed validation never leaves a broken config on disk.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "ignore": "^7.0.5",
         "json5": "^2.2.3",
         "zod": "^4.0.0"
       },
@@ -6944,7 +6945,6 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "ignore": "^7.0.5",
     "json5": "^2.2.3",
     "zod": "^4.0.0"
   },

--- a/src/lib/customManagerPreview.ts
+++ b/src/lib/customManagerPreview.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import ignore, { type Ignore } from "ignore";
 
 export interface CustomManager {
   customType: string;
@@ -206,26 +207,104 @@ function lineNumberAt(content: string, index: number): number {
   return line;
 }
 
+/**
+ * Honor `.gitignore` like git does: each `.gitignore` applies to the subtree it
+ * lives in, patterns are resolved relative to that directory. We keep a stack
+ * of `(prefix, Ignore)` levels as we descend. `.git/info/exclude` is loaded at
+ * the root level. `SKIP_DIRS` stays as a safety net so `.git/` and
+ * `node_modules/` get pruned even when no `.gitignore` is present (e.g. the
+ * user pointed the tool at a non-git directory).
+ */
+interface IgnoreLevel {
+  /** Prefix relative to repo root, with trailing `/` (empty string for root). */
+  prefix: string;
+  ig: Ignore;
+}
+
+async function readMaybe(abs: string): Promise<string | null> {
+  try {
+    return await fs.readFile(abs, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function loadGitignore(
+  root: string,
+  relDir: string,
+  levels: IgnoreLevel[],
+): Promise<IgnoreLevel[]> {
+  const content = await readMaybe(path.join(root, relDir, ".gitignore"));
+  if (!content) return levels;
+  const posixPrefix = relDir === "" ? "" : `${toPosix(relDir)}/`;
+  return [...levels, { prefix: posixPrefix, ig: ignore().add(content) }];
+}
+
+function isIgnored(
+  relPath: string,
+  isDir: boolean,
+  levels: IgnoreLevel[],
+): boolean {
+  for (const level of levels) {
+    const sub =
+      level.prefix === ""
+        ? relPath
+        : relPath.startsWith(level.prefix)
+          ? relPath.slice(level.prefix.length)
+          : null;
+    if (sub === null || sub === "") continue;
+    // `ignore` treats a trailing slash as "this is a directory", which is what
+    // lets patterns like `dist/` match directory paths.
+    if (level.ig.ignores(isDir ? `${sub}/` : sub)) return true;
+  }
+  return false;
+}
+
+function toPosix(p: string): string {
+  return p.split(path.sep).join("/");
+}
+
 async function* walk(root: string): AsyncGenerator<string> {
-  const stack: string[] = [""];
-  while (stack.length > 0) {
-    const relDir = stack.pop()!;
-    const absDir = path.join(root, relDir);
-    let entries;
-    try {
-      entries = await fs.readdir(absDir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        if (SKIP_DIRS.has(entry.name)) continue;
-        stack.push(path.join(relDir, entry.name));
-      } else if (entry.isFile()) {
-        // Always emit POSIX-style paths so users on macOS/Linux/Windows write
-        // the same fileMatch regexes.
-        yield path.join(relDir, entry.name).split(path.sep).join("/");
-      }
+  // Seed the root level with `.gitignore` plus `.git/info/exclude` (the
+  // per-clone exclude file). Both are optional.
+  const rootIg = ignore();
+  const rootGitignore = await readMaybe(path.join(root, ".gitignore"));
+  if (rootGitignore) rootIg.add(rootGitignore);
+  const infoExclude = await readMaybe(path.join(root, ".git", "info", "exclude"));
+  if (infoExclude) rootIg.add(infoExclude);
+  const rootLevels: IgnoreLevel[] = [{ prefix: "", ig: rootIg }];
+
+  yield* walkDir(root, "", rootLevels);
+}
+
+async function* walkDir(
+  root: string,
+  relDir: string,
+  levels: IgnoreLevel[],
+): AsyncGenerator<string> {
+  let entries;
+  try {
+    entries = await fs.readdir(path.join(root, relDir), { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  // A nested `.gitignore` only affects this directory's subtree — add it to
+  // the stack on entry. (The root `.gitignore` is already in `levels`.)
+  const dirLevels = relDir === "" ? levels : await loadGitignore(root, relDir, levels);
+
+  for (const entry of entries) {
+    const relPath =
+      relDir === "" ? entry.name : `${toPosix(relDir)}/${entry.name}`;
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      if (isIgnored(relPath, true, dirLevels)) continue;
+      yield* walkDir(root, path.join(relDir, entry.name), dirLevels);
+    } else if (entry.isFile()) {
+      if (isIgnored(relPath, false, dirLevels)) continue;
+      // Always emit POSIX-style paths so users on macOS/Linux/Windows write
+      // the same fileMatch regexes.
+      yield toPosix(relPath);
     }
   }
 }

--- a/src/tools/previewCustomManager.ts
+++ b/src/tools/previewCustomManager.ts
@@ -36,7 +36,7 @@ export function registerPreviewCustomManager(server: McpServer): void {
         "  - Only `customType: \"regex\"` is supported.",
         "  - `matchStringsStrategy` other than `any` (the default) is not implemented; a warning is emitted.",
         "  - Template substitution handles only `{{groupName}}` references, not full Handlebars helpers.",
-        "  - `.gitignore` is not honored; `node_modules/` and `.git/` are always skipped.",
+        "  - `.gitignore` (and `.git/info/exclude`, plus nested `.gitignore`s) is honored like `git` does. `node_modules/` and `.git/` are always skipped as a safety net, even without a `.gitignore`.",
         "",
         "Run the `dry_run` tool afterwards for full-fidelity confirmation.",
       ].join("\n"),

--- a/test/unit/customManagerPreview.test.ts
+++ b/test/unit/customManagerPreview.test.ts
@@ -143,6 +143,74 @@ describe("previewCustomManager", () => {
     ).rejects.toThrow(/Invalid regex/);
   });
 
+  it("honors a root .gitignore — generated dirs don't crowd out real hits", async () => {
+    // Acceptance from issue #21: 3000 junk files in a gitignored dist/ must
+    // not burn the maxFilesScanned budget. We use a lower cap (500) to keep
+    // the test fast while still proving the point.
+    await writeFile(path.join(repo, ".gitignore"), "dist/\ncoverage/\n");
+    await mkdir(path.join(repo, "dist"), { recursive: true });
+    for (let i = 0; i < 3000; i++) {
+      await writeFile(path.join(repo, `dist/junk-${i}.txt`), "noise");
+    }
+    await writeFile(path.join(repo, "Dockerfile"), "FROM alpine:3.19");
+
+    const result = await previewCustomManager(
+      repo,
+      {
+        customType: "regex",
+        fileMatch: ["(^|/)Dockerfile$"],
+        matchStrings: ["FROM (?<depName>[^:\\s]+):(?<currentValue>\\S+)"],
+      },
+      { maxFilesScanned: 500 },
+    );
+    expect(result.filesMatched).toEqual(["Dockerfile"]);
+    expect(result.warnings.some((w) => /Stopped after scanning/.test(w))).toBe(false);
+    // We walked the real files, not the 3000 junk ones.
+    expect(result.filesScanned).toBeLessThan(10);
+  });
+
+  it("honors .git/info/exclude in addition to .gitignore", async () => {
+    await mkdir(path.join(repo, ".git/info"), { recursive: true });
+    await writeFile(path.join(repo, ".git/info/exclude"), "secret.txt\n");
+    await writeFile(path.join(repo, "secret.txt"), "shh");
+    await writeFile(path.join(repo, "public.txt"), "ok");
+
+    const result = await previewCustomManager(repo, {
+      customType: "regex",
+      fileMatch: ["\\.txt$"],
+      matchStrings: ["(?<depName>\\w+)"],
+    });
+    expect(result.filesMatched).toEqual(["public.txt"]);
+  });
+
+  it("honors a nested .gitignore only within its own subtree", async () => {
+    // `foo.txt` in `sub/.gitignore` must NOT match `foo.txt` at the root.
+    await mkdir(path.join(repo, "sub"), { recursive: true });
+    await writeFile(path.join(repo, "sub/.gitignore"), "foo.txt\n");
+    await writeFile(path.join(repo, "sub/foo.txt"), "hidden");
+    await writeFile(path.join(repo, "foo.txt"), "visible");
+
+    const result = await previewCustomManager(repo, {
+      customType: "regex",
+      fileMatch: ["foo\\.txt$"],
+      matchStrings: ["(?<v>\\S+)"],
+    });
+    expect(result.filesMatched).toEqual(["foo.txt"]);
+  });
+
+  it("respects negation in .gitignore", async () => {
+    await writeFile(path.join(repo, ".gitignore"), "*.log\n!keep.log\n");
+    await writeFile(path.join(repo, "drop.log"), "x");
+    await writeFile(path.join(repo, "keep.log"), "x");
+
+    const result = await previewCustomManager(repo, {
+      customType: "regex",
+      fileMatch: ["\\.log$"],
+      matchStrings: ["(?<v>\\S+)"],
+    });
+    expect(result.filesMatched).toEqual(["keep.log"]);
+  });
+
   it("honors maxHitsPerFile and records a warning", async () => {
     const lines = Array.from({ length: 20 }, (_, i) => `pkg=foo${i} ver=${i}`).join("\n");
     await writeFile(path.join(repo, "many.txt"), lines);


### PR DESCRIPTION
## Summary
- Walker in `src/lib/customManagerPreview.ts` now honors `.gitignore` (root + nested) and `.git/info/exclude` via the `ignore` package — the same one Renovate uses — so generated/vendored dirs like `dist/`, `.next/`, `target/`, `coverage/`, `__pycache__/` no longer burn through the `maxFilesScanned` cap before real hits are reached.
- `.git/` and `node_modules/` remain hard-skipped as a safety net for directories without a `.gitignore`.
- Tool description and README design notes updated.
- `ignore` promoted from transitive (via Renovate devDep) to direct runtime dep.

Closes #21.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 98/98 pass (9 existing + 4 new unit tests in `test/unit/customManagerPreview.test.ts`)
- [x] New test: 3000 junk files in a gitignored `dist/` do **not** consume the scan budget (acceptance scenario from the issue)
- [x] New test: `.git/info/exclude` is honored in addition to `.gitignore`
- [x] New test: a nested `.gitignore` only scopes to its own subtree (pattern in `sub/.gitignore` doesn't match root-level files)
- [x] New test: negation patterns (`!keep.log`) work correctly