### PR TITLE
feat(presets): add renovate://presets/{namespace} sub-resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Seven tools plus a preset reference:
 | `validate_config` | Run `renovate-config-validator` against a file or inline object. |
 | `dry_run` | Run Renovate with `--platform=local --dry-run`, return the structured JSON report (no PRs, no pushes). |
 | `write_config` | Validate, then write a config to disk (temp-file → validate → atomic rename). Refuses to save invalid configs unless `force: true`. |
-| `renovate://presets` (resource) | Markdown index of every built-in preset (1000+), grouped by namespace. Snapshot from the installed `renovate` devDep. |
+| `renovate://presets` (resource) | Thin markdown index of every namespace (with preset counts) covering all 1000+ built-in presets. Snapshot from the installed `renovate` devDep. |
+| `renovate://presets/{namespace}` (resource template) | Markdown listing of every preset in a single namespace (e.g. `renovate://presets/config`). Fetch this instead of the full index when the LLM only cares about one namespace — cuts token cost by roughly 1/N where N is the number of namespaces. |
 | `renovate://preset/{name}` (resource template) | Expanded JSON body (description, extends, packageRules, …) for any single built-in preset. E.g. `renovate://preset/config:recommended`. |
 
 ## Requirements

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ const BASE_INSTRUCTIONS = [
   "  6. write_config           — save the agreed-upon config (validates first)",
   "",
   "If any tool fails unexpectedly, call check_setup to diagnose CLI availability.",
-  "Built-in preset reference is available at renovate://presets.",
+  "Built-in preset reference: renovate://presets (namespace index), renovate://presets/{namespace} (one namespace), renovate://preset/{name} (one preset's expanded JSON).",
 ].join("\n");
 
 const setup = await checkSetup();

--- a/src/resources/presets.ts
+++ b/src/resources/presets.ts
@@ -6,13 +6,31 @@ import {
   RENOVATE_VERSION,
 } from "../data/presets.generated.js";
 
+interface NamespaceEntry {
+  name: string;
+  description: string | null;
+}
+
+const BY_NAMESPACE: Map<string, NamespaceEntry[]> = (() => {
+  const map = new Map<string, NamespaceEntry[]>();
+  for (const name of PRESET_NAMES) {
+    const preset = PRESETS[name]!;
+    const bucket = map.get(preset.namespace) ?? [];
+    bucket.push({ name, description: preset.description });
+    map.set(preset.namespace, bucket);
+  }
+  return map;
+})();
+
+const NAMESPACES: string[] = Array.from(BY_NAMESPACE.keys()).sort();
+
 export function registerPresetResources(server: McpServer): void {
   server.registerResource(
     "renovate-presets",
     "renovate://presets",
     {
-      title: "Renovate built-in preset index",
-      description: `Markdown index of all ${PRESET_NAMES.length} built-in Renovate presets (from renovate v${RENOVATE_VERSION}). Grouped by namespace. Fetch renovate://preset/{name} for a single preset's expanded JSON.`,
+      title: "Renovate built-in preset namespace index",
+      description: `Thin markdown index of the ${NAMESPACES.length} namespaces covering all ${PRESET_NAMES.length} built-in Renovate presets (from renovate v${RENOVATE_VERSION}). Fetch renovate://presets/{namespace} for one namespace's preset list, or renovate://preset/{name} for a single preset's expanded JSON.`,
       mimeType: "text/markdown",
     },
     async () => ({
@@ -20,10 +38,49 @@ export function registerPresetResources(server: McpServer): void {
         {
           uri: "renovate://presets",
           mimeType: "text/markdown",
-          text: renderIndex(),
+          text: renderNamespaceIndex(),
         },
       ],
     }),
+  );
+
+  server.registerResource(
+    "renovate-presets-namespace",
+    new ResourceTemplate("renovate://presets/{namespace}", {
+      list: async () => ({
+        resources: NAMESPACES.map((ns) => ({
+          uri: `renovate://presets/${ns}`,
+          name: `renovate-presets-${ns}`,
+          description: `Markdown listing of the ${BY_NAMESPACE.get(ns)!.length} built-in presets in the \`${ns}\` namespace.`,
+          mimeType: "text/markdown",
+        })),
+      }),
+    }),
+    {
+      title: "Renovate built-in presets — single namespace",
+      description:
+        "Markdown listing of every built-in Renovate preset in a single namespace (e.g. `config`, `docker`, `default`). Fetch renovate://presets for the namespace index.",
+      mimeType: "text/markdown",
+    },
+    async (uri, variables) => {
+      const raw = variables.namespace;
+      const ns = typeof raw === "string" ? decodeURIComponent(raw) : "";
+      const bucket = BY_NAMESPACE.get(ns);
+      if (!bucket) {
+        throw new Error(
+          `Unknown preset namespace: ${ns}. Fetch renovate://presets for the list of namespaces.`,
+        );
+      }
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "text/markdown",
+            text: renderNamespace(ns, bucket),
+          },
+        ],
+      };
+    },
   );
 
   server.registerResource(
@@ -78,30 +135,37 @@ export function registerPresetResources(server: McpServer): void {
   );
 }
 
-function renderIndex(): string {
-  const byNamespace = new Map<string, Array<{ name: string; description: string | null }>>();
-  for (const name of PRESET_NAMES) {
-    const preset = PRESETS[name]!;
-    const bucket = byNamespace.get(preset.namespace) ?? [];
-    bucket.push({ name, description: preset.description });
-    byNamespace.set(preset.namespace, bucket);
-  }
-  const namespaces = Array.from(byNamespace.keys()).sort();
+function renderNamespaceIndex(): string {
   const lines: string[] = [
     "# Renovate built-in presets",
     "",
-    `Snapshot from renovate v${RENOVATE_VERSION} — **${PRESET_NAMES.length} presets** across ${namespaces.length} namespaces.`,
+    `Snapshot from renovate v${RENOVATE_VERSION} — **${PRESET_NAMES.length} presets** across ${NAMESPACES.length} namespaces.`,
+    "",
+    "Fetch `renovate://presets/<namespace>` for the full list of presets in one namespace, or `renovate://preset/<name>` for a single preset's expanded JSON.",
+    "",
+    "| Namespace | Presets | Resource |",
+    "| --- | ---: | --- |",
+  ];
+  for (const ns of NAMESPACES) {
+    const count = BY_NAMESPACE.get(ns)!.length;
+    lines.push(`| \`${ns}\` | ${count} | \`renovate://presets/${ns}\` |`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function renderNamespace(ns: string, bucket: NamespaceEntry[]): string {
+  const lines: string[] = [
+    `# Renovate \`${ns}\` presets`,
+    "",
+    `Snapshot from renovate v${RENOVATE_VERSION} — **${bucket.length} preset${bucket.length === 1 ? "" : "s"}** in the \`${ns}\` namespace.`,
     "",
     "Reference any of these in the `extends` array of your config. Fetch `renovate://preset/<name>` for the expanded JSON of a single preset.",
     "",
   ];
-  for (const ns of namespaces) {
-    const items = byNamespace.get(ns)!;
-    lines.push(`## \`${ns}\` (${items.length})`, "");
-    for (const { name, description } of items) {
-      lines.push(description ? `- \`${name}\` — ${description}` : `- \`${name}\``);
-    }
-    lines.push("");
+  for (const { name, description } of bucket) {
+    lines.push(description ? `- \`${name}\` — ${description}` : `- \`${name}\``);
   }
+  lines.push("");
   return lines.join("\n");
 }

--- a/test/integration/presets.test.ts
+++ b/test/integration/presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { startServer, type McpSession } from "../helpers/mcpSession.js";
-import { PRESET_NAMES } from "../../src/data/presets.generated.js";
+import { PRESET_NAMES, PRESETS } from "../../src/data/presets.generated.js";
 
 let session: McpSession;
 
@@ -9,7 +9,7 @@ afterEach(async () => {
 });
 
 describe("renovate://presets index", () => {
-  it("returns markdown grouped by namespace with the total count", async () => {
+  it("returns a thin namespace index, not the full preset list", async () => {
     session = await startServer();
     const res = await session.request<{
       contents: Array<{ uri: string; mimeType: string; text: string }>;
@@ -17,8 +17,37 @@ describe("renovate://presets index", () => {
     const content = res.result?.contents[0];
     expect(content?.mimeType).toBe("text/markdown");
     expect(content?.text).toContain(`**${PRESET_NAMES.length} presets**`);
-    expect(content?.text).toContain("## `config`");
+    expect(content?.text).toContain("| `config` |");
+    expect(content?.text).toContain("`renovate://presets/config`");
+    // The index must not inline every preset name — that's the whole point.
+    expect(content?.text).not.toContain("`config:recommended`");
+  });
+});
+
+describe("renovate://presets/{namespace} template", () => {
+  it("returns the markdown listing for a single namespace", async () => {
+    session = await startServer();
+    const res = await session.request<{
+      contents: Array<{ uri: string; mimeType: string; text: string }>;
+    }>("resources/read", { uri: "renovate://presets/config" });
+    const content = res.result?.contents[0];
+    expect(content?.mimeType).toBe("text/markdown");
+    expect(content?.text).toContain("# Renovate `config` presets");
     expect(content?.text).toContain("`config:recommended`");
+    // Must not leak presets from other namespaces.
+    const otherNamespaceSample = PRESET_NAMES.find(
+      (n) => PRESETS[n]!.namespace !== "config",
+    )!;
+    expect(content?.text).not.toContain(`\`${otherNamespaceSample}\``);
+  });
+
+  it("returns an error for an unknown namespace", async () => {
+    session = await startServer();
+    const res = await session.request("resources/read", {
+      uri: "renovate://presets/nope-not-a-namespace",
+    });
+    expect(res.error).toBeDefined();
+    expect(res.error?.message ?? "").toMatch(/unknown preset namespace/i);
   });
 });
 
@@ -50,16 +79,21 @@ describe("renovate://preset/{name} template", () => {
 });
 
 describe("resources/list", () => {
-  it("enumerates both the index and per-preset entries", async () => {
+  it("enumerates the index, per-namespace sub-resources, and per-preset entries", async () => {
     session = await startServer();
     const res = await session.request<{
       resources: Array<{ uri: string; name?: string }>;
     }>("resources/list");
     const uris = (res.result?.resources ?? []).map((r) => r.uri);
     expect(uris).toContain("renovate://presets");
+    expect(uris).toContain("renovate://presets/config");
     expect(uris).toContain("renovate://preset/config:recommended");
-    // Quick sanity: we should be surfacing a lot of presets, not just 20.
+    // Sanity: many per-preset entries, and a modest but non-trivial number of namespaces.
     const perPreset = uris.filter((u) => u.startsWith("renovate://preset/"));
     expect(perPreset.length).toBeGreaterThan(500);
+    const perNamespace = uris.filter((u) =>
+      /^renovate:\/\/presets\/[^/]+$/.test(u),
+    );
+    expect(perNamespace.length).toBeGreaterThan(5);
   });
 });


### PR DESCRIPTION
## Summary
- `renovate://presets` becomes a thin namespace index — markdown table of namespace + preset count + sub-resource URI — instead of inlining all 1000+ presets
- New `renovate://presets/{namespace}` resource template returns the markdown listing for a single namespace; its `list` callback surfaces one entry per namespace so discovery via `resources/list` still works
- `renovate://preset/{name}` stays unchanged

Clients that only need one namespace (e.g. `config:*`, `docker:*`) now pay roughly 1/N the token cost of the old single-document index.

Closes #26

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (96/96 passing)
- [ ] Manual: read `renovate://presets` and confirm it's the thin namespace table
- [ ] Manual: read `renovate://presets/config` and confirm it lists only `config:*` presets
- [ ] Manual: read `renovate://presets/nope` and confirm it errors with the "unknown preset namespace" message
- [ ] Manual: `resources/list` includes `renovate://presets`, each `renovate://presets/<ns>`, and each `renovate://preset/<name>`