### PR TITLE
fix(write_config): realpath repoPath before escape check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Commit authorship
+
+Never add a `Co-Authored-By: Claude …` trailer (or any other Claude attribution) to commits in this repo. Commits should be authored under the human's name only.
+
 ## Project
 
 MCP server that helps users design Renovate configurations interactively. TypeScript, Node ≥ 24 (aligns with Renovate's own engine requirement), built with `@modelcontextprotocol/sdk` 1.x, stdio transport.

--- a/src/tools/writeConfig.ts
+++ b/src/tools/writeConfig.ts
@@ -4,6 +4,27 @@ import { promises as fs } from "node:fs";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { run, resolveRenovateTool, formatMissingBinaryError } from "../lib/renovateCli.js";
 
+// Resolve symlinks in `p`, walking up to the nearest existing ancestor when
+// tail components don't exist yet (e.g. a new subdir we're about to mkdir).
+// This matters for the escape check: `fs.rename` follows symlinks along the
+// parent path, so the check must compare the same canonical tree.
+async function resolveWithExistingAncestor(p: string): Promise<string> {
+  const suffixes: string[] = [];
+  let current = p;
+  while (true) {
+    try {
+      const resolved = await fs.realpath(current);
+      return suffixes.length ? path.join(resolved, ...suffixes) : resolved;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      const parent = path.dirname(current);
+      if (parent === current) throw err;
+      suffixes.unshift(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
 export function registerWriteConfig(server: McpServer): void {
   server.registerTool(
     "write_config",
@@ -28,7 +49,11 @@ export function registerWriteConfig(server: McpServer): void {
       const repoAbs = path.resolve(repoPath);
       const target = path.resolve(repoAbs, filename);
       const rel = path.relative(repoAbs, target);
-      if (rel.startsWith("..") || path.isAbsolute(rel)) {
+
+      const repoReal = await resolveWithExistingAncestor(repoAbs);
+      const parentReal = await resolveWithExistingAncestor(path.dirname(target));
+      const checkRel = path.relative(repoReal, parentReal);
+      if (checkRel.startsWith("..") || path.isAbsolute(checkRel)) {
         return {
           isError: true,
           content: [{ type: "text", text: "filename escapes repoPath" }],

--- a/test/integration/writeConfig.test.ts
+++ b/test/integration/writeConfig.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, writeFile, readFile, readdir, chmod } from "node:fs/promises";
+import { mkdtemp, rm, writeFile, readFile, readdir, chmod, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { startServer, type McpSession } from "../helpers/mcpSession.js";
@@ -85,6 +85,35 @@ describe("write_config", () => {
     const files = await readdir(repo);
     expect(files).not.toContain("renovate.json");
     expect(files.some((f) => f.endsWith(".renovate-mcp-tmp"))).toBe(false);
+  });
+
+  it("rejects a filename whose resolved parent escapes repoPath via a symlink", async () => {
+    session = await startServer();
+
+    const outside = await mkdtemp(path.join(tmpdir(), "rmcp-outside-"));
+    try {
+      await symlink(outside, path.join(repo, "escape"));
+
+      const res = await session.request<{
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+      }>("tools/call", {
+        name: "write_config",
+        arguments: {
+          repoPath: repo,
+          filename: "escape/renovate.json",
+          config: { extends: ["config:recommended"] },
+        },
+      });
+
+      expect(res.result?.isError).toBe(true);
+      expect(res.result!.content[0]!.text).toContain("escapes repoPath");
+
+      const leaked = await readdir(outside);
+      expect(leaked).toHaveLength(0);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
   });
 
   it("writes anyway when force=true and validation fails", async () => {


### PR DESCRIPTION
## Summary

Closes #20.

The `write_config` path-escape check previously ran on unresolved paths — so a symlink inside `repoPath` pointing outside the tree slipped past the guard, and the escape only materialized once `fs.rename` followed the link. Since `repoPath` comes from an LLM, that guard needs to hold against crafted input.

- `src/tools/writeConfig.ts`: realpath `repoPath` and `path.dirname(target)` before the prefix check. New `resolveWithExistingAncestor` helper walks up to the nearest existing ancestor when the target's parent subdir doesn't exist yet (e.g. writing `.github/renovate.json`), then rejoins the un-traversed suffix. The user-facing `path` in the success response still uses the unresolved relative form.
- `test/integration/writeConfig.test.ts`: new integration test creates a symlink inside a fake repo pointing at an outside tmp dir, calls `write_config` with `filename: "escape/renovate.json"`, and asserts the tool rejects it and leaves the outside tree untouched.
- A second commit adds a CLAUDE.md note about commit authorship conventions — unrelated to the fix, bundled for convenience.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (9 files, 101 tests passing, including the new symlink-escape case)
- [ ] Reviewer: sanity-check that the response `path` field still uses the user-facing filename (not the realpath'd form)