### PR TITLE
feat(resolve_config): distinguish rate-limit from auth failures on preset fetches

### DIFF
--- a/src/lib/externalPresetFetcher.ts
+++ b/src/lib/externalPresetFetcher.ts
@@ -67,6 +67,8 @@ function dispatch(parsed: ParsedPreset, options: FetchOptions): Promise<FetchRes
   }
 }
 
+type Platform = "github" | "gitlab";
+
 async function fetchGitHub(
   parsed: ParsedPreset,
   timeoutMs: number,
@@ -88,7 +90,7 @@ async function fetchGitHub(
     "User-Agent": "renovate-mcp",
   };
   if (token) headers.Authorization = `Bearer ${token}`;
-  return fetchJson(url, headers, timeoutMs, parsed.original, fetchImpl);
+  return fetchJson(url, headers, timeoutMs, parsed.original, fetchImpl, "github");
 }
 
 async function fetchGitLab(
@@ -109,7 +111,7 @@ async function fetchGitLab(
   const token = process.env.GITLAB_TOKEN || process.env.RENOVATE_TOKEN;
   const headers: Record<string, string> = { "User-Agent": "renovate-mcp" };
   if (token) headers["PRIVATE-TOKEN"] = token;
-  return fetchJson(url, headers, timeoutMs, parsed.original, fetchImpl);
+  return fetchJson(url, headers, timeoutMs, parsed.original, fetchImpl, "gitlab");
 }
 
 function presetFileName(parsed: ParsedPreset): string {
@@ -126,18 +128,49 @@ function encodeFilePath(file: string): string {
   return file.split("/").map(encodeURIComponent).join("/");
 }
 
+function detectRateLimit(
+  res: Response,
+  platform: Platform,
+  presetName: string,
+): string | undefined {
+  if (platform === "github" && res.status === 403) {
+    if (res.headers.get("x-ratelimit-remaining") !== "0") return undefined;
+    const resetIso = parseEpochHeader(res.headers.get("x-ratelimit-reset"));
+    const resetClause = resetIso ? ` (resets at ${resetIso})` : "";
+    return `GitHub API rate limit exceeded${resetClause} when fetching ${presetName}. Set GITHUB_TOKEN for an authenticated limit, or wait for reset.`;
+  }
+  if (platform === "gitlab" && res.status === 429) {
+    const resetIso = parseEpochHeader(res.headers.get("ratelimit-reset"));
+    const resetClause = resetIso ? ` (resets at ${resetIso})` : "";
+    return `GitLab API rate limit exceeded${resetClause} when fetching ${presetName}. Set GITLAB_TOKEN for an authenticated limit, or wait for reset.`;
+  }
+  return undefined;
+}
+
+function parseEpochHeader(raw: string | null): string | undefined {
+  if (!raw) return undefined;
+  const seconds = Number.parseInt(raw, 10);
+  if (!Number.isFinite(seconds) || seconds <= 0) return undefined;
+  const date = new Date(seconds * 1000);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
 async function fetchJson(
   url: string,
   headers: Record<string, string>,
   timeoutMs: number,
   presetName: string,
   fetchImpl: typeof fetch,
+  platform: Platform,
 ): Promise<FetchResult> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const res = await fetchImpl(url, { headers, signal: controller.signal });
     if (!res.ok) {
+      const rateLimit = detectRateLimit(res, platform, presetName);
+      if (rateLimit) return { ok: false, reason: rateLimit };
       return {
         ok: false,
         reason: `HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ""} when fetching ${presetName}`,

--- a/test/unit/externalPresetFetcher.test.ts
+++ b/test/unit/externalPresetFetcher.test.ts
@@ -2,11 +2,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { fetchExternalPreset, type FetchOptions } from "../../src/lib/externalPresetFetcher.js";
 import { parsePreset } from "../../src/lib/presetResolver.js";
 
-function makeResponse(body: unknown, init: { status?: number; statusText?: string } = {}): Response {
+function makeResponse(
+  body: unknown,
+  init: { status?: number; statusText?: string; headers?: Record<string, string> } = {},
+): Response {
   const text = typeof body === "string" ? body : JSON.stringify(body);
   return new Response(text, {
     status: init.status ?? 200,
     statusText: init.statusText ?? "OK",
+    headers: init.headers,
   });
 }
 
@@ -122,6 +126,97 @@ describe("fetchExternalPreset — github", () => {
     await fetchExternalPreset(p, { fetchImpl, cache });
     await fetchExternalPreset(p, { fetchImpl, cache });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fetchExternalPreset — rate limits", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("surfaces a GitHub 403 with X-RateLimit-Remaining: 0 as a rate-limit reason", async () => {
+    const resetEpoch = Math.floor(Date.parse("2025-01-02T03:04:05Z") / 1000);
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      makeResponse(
+        { message: "API rate limit exceeded for 1.2.3.4" },
+        {
+          status: 403,
+          statusText: "Forbidden",
+          headers: {
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": String(resetEpoch),
+          },
+        },
+      ),
+    );
+    const result = await fetchExternalPreset(parsePreset("github>acme/cfg"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/GitHub API rate limit exceeded/);
+      expect(result.reason).toMatch(/2025-01-02T03:04:05\.000Z/);
+      expect(result.reason).toMatch(/GITHUB_TOKEN/);
+      expect(result.reason).not.toMatch(/HTTP 403/);
+    }
+  });
+
+  it("keeps the generic HTTP message for a GitHub 403 without the rate-limit header", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      makeResponse("forbidden", { status: 403, statusText: "Forbidden" }),
+    );
+    const result = await fetchExternalPreset(parsePreset("github>acme/cfg"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/HTTP 403 Forbidden/);
+      expect(result.reason).not.toMatch(/rate limit/i);
+    }
+  });
+
+  it("falls back to a rate-limit message without reset time when X-RateLimit-Reset is malformed", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      makeResponse("forbidden", {
+        status: 403,
+        statusText: "Forbidden",
+        headers: {
+          "X-RateLimit-Remaining": "0",
+          "X-RateLimit-Reset": "not-a-number",
+        },
+      }),
+    );
+    const result = await fetchExternalPreset(parsePreset("github>acme/cfg"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/GitHub API rate limit exceeded/);
+      expect(result.reason).not.toMatch(/resets at/);
+    }
+  });
+
+  it("surfaces a GitLab 429 with RateLimit-Reset as a rate-limit reason", async () => {
+    const resetEpoch = Math.floor(Date.parse("2025-06-07T08:09:10Z") / 1000);
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      makeResponse("too many", {
+        status: 429,
+        statusText: "Too Many Requests",
+        headers: { "RateLimit-Reset": String(resetEpoch) },
+      }),
+    );
+    const result = await fetchExternalPreset(parsePreset("gitlab>acme/cfg"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/GitLab API rate limit exceeded/);
+      expect(result.reason).toMatch(/2025-06-07T08:09:10\.000Z/);
+      expect(result.reason).toMatch(/GITLAB_TOKEN/);
+      expect(result.reason).not.toMatch(/HTTP 429/);
+    }
+  });
+
+  it("falls back to a rate-limit message without reset time for a GitLab 429 missing RateLimit-Reset", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      makeResponse("too many", { status: 429, statusText: "Too Many Requests" }),
+    );
+    const result = await fetchExternalPreset(parsePreset("gitlab>acme/cfg"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/GitLab API rate limit exceeded/);
+      expect(result.reason).not.toMatch(/resets at/);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Detect GitHub 403 + `X-RateLimit-Remaining: 0` and GitLab 429 when fetching external presets, and surface a rate-limit-specific reason that includes the ISO-8601 reset time
- Missing or malformed reset headers degrade gracefully (GitHub falls back to the existing auth-style message; GitLab drops the reset clause but keeps the 'rate limit exceeded' wording)
- Plain 403s without the rate-limit signature keep the existing `HTTP 403 Forbidden …` message — no behaviour change

Closes #36.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (137/137 — 5 new unit tests cover GitHub valid-reset, GitHub auth-failure passthrough, GitHub malformed-reset, GitLab valid-reset, GitLab missing-reset)