### PR TITLE
feat(resolve_config): enrich 401/403 preset-fetch errors with credential source and URL

### DIFF
--- a/src/lib/externalPresetFetcher.ts
+++ b/src/lib/externalPresetFetcher.ts
@@ -84,13 +84,13 @@ async function fetchGitHub(
   const url = `${apiBase}/repos/${parsed.repoPath}/contents/${encodeFilePath(
     file,
   )}?ref=${encodeURIComponent(ref)}`;
-  const token = process.env.GITHUB_TOKEN || process.env.RENOVATE_TOKEN;
+  const credential = resolveCredential(["GITHUB_TOKEN", "RENOVATE_TOKEN"]);
   const headers: Record<string, string> = {
     Accept: "application/vnd.github.raw",
     "User-Agent": "renovate-mcp",
   };
-  if (token) headers.Authorization = `Bearer ${token}`;
-  return fetchJson(url, headers, timeoutMs, parsed.original, fetchImpl, "github");
+  if (credential.token) headers.Authorization = `Bearer ${credential.token}`;
+  return fetchJson(url, headers, timeoutMs, parsed.original, fetchImpl, "github", credential);
 }
 
 async function fetchGitLab(
@@ -108,10 +108,24 @@ async function fetchGitLab(
   const url = `${apiBase}/projects/${encodeURIComponent(
     parsed.repoPath,
   )}/repository/files/${encodeURIComponent(file)}/raw?ref=${encodeURIComponent(ref)}`;
-  const token = process.env.GITLAB_TOKEN || process.env.RENOVATE_TOKEN;
+  const credential = resolveCredential(["GITLAB_TOKEN", "RENOVATE_TOKEN"]);
   const headers: Record<string, string> = { "User-Agent": "renovate-mcp" };
-  if (token) headers["PRIVATE-TOKEN"] = token;
-  return fetchJson(url, headers, timeoutMs, parsed.original, fetchImpl, "gitlab");
+  if (credential.token) headers["PRIVATE-TOKEN"] = credential.token;
+  return fetchJson(url, headers, timeoutMs, parsed.original, fetchImpl, "gitlab", credential);
+}
+
+interface Credential {
+  envVar: string | null;
+  token: string | undefined;
+  triedVars: string[];
+}
+
+function resolveCredential(vars: string[]): Credential {
+  for (const envVar of vars) {
+    const value = process.env[envVar];
+    if (value) return { envVar, token: value, triedVars: vars };
+  }
+  return { envVar: null, token: undefined, triedVars: vars };
 }
 
 function presetFileName(parsed: ParsedPreset): string {
@@ -163,6 +177,7 @@ async function fetchJson(
   presetName: string,
   fetchImpl: typeof fetch,
   platform: Platform,
+  credential: Credential,
 ): Promise<FetchResult> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -171,6 +186,13 @@ async function fetchJson(
     if (!res.ok) {
       const rateLimit = detectRateLimit(res, platform, presetName);
       if (rateLimit) return { ok: false, reason: rateLimit };
+      if (res.status === 401 || res.status === 403) {
+        const body = await safeReadText(res);
+        return {
+          ok: false,
+          reason: formatAuthFailure(res.status, presetName, url, credential, body),
+        };
+      }
       return {
         ok: false,
         reason: `HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ""} when fetching ${presetName}`,
@@ -207,4 +229,40 @@ async function fetchJson(
   } finally {
     clearTimeout(timer);
   }
+}
+
+const AUTH_BODY_MAX = 500;
+
+async function safeReadText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return "";
+  }
+}
+
+function formatAuthFailure(
+  status: number,
+  presetName: string,
+  url: string,
+  credential: Credential,
+  body: string,
+): string {
+  const lines: string[] = [`HTTP ${status} when fetching ${presetName}`];
+  lines.push(`  URL:         ${url}`);
+  lines.push(`  Credential:  ${formatCredential(credential)}`);
+  const trimmed = body.trim();
+  if (trimmed) {
+    const snippet =
+      trimmed.length > AUTH_BODY_MAX
+        ? `${trimmed.slice(0, AUTH_BODY_MAX)}… [truncated]`
+        : trimmed;
+    lines.push(`  Response:    ${snippet}`);
+  }
+  return lines.join("\n");
+}
+
+function formatCredential(credential: Credential): string {
+  if (credential.envVar) return `${credential.envVar} (present)`;
+  return `none (tried ${credential.triedVars.join(", ")})`;
 }

--- a/test/unit/externalPresetFetcher.test.ts
+++ b/test/unit/externalPresetFetcher.test.ts
@@ -157,14 +157,14 @@ describe("fetchExternalPreset — rate limits", () => {
     }
   });
 
-  it("keeps the generic HTTP message for a GitHub 403 without the rate-limit header", async () => {
+  it("does not classify a GitHub 403 without the rate-limit header as rate-limited", async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       makeResponse("forbidden", { status: 403, statusText: "Forbidden" }),
     );
     const result = await fetchExternalPreset(parsePreset("github>acme/cfg"), { fetchImpl });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.reason).toMatch(/HTTP 403 Forbidden/);
+      expect(result.reason).toMatch(/HTTP 403 when fetching/);
       expect(result.reason).not.toMatch(/rate limit/i);
     }
   });
@@ -273,6 +273,143 @@ describe("fetchExternalPreset — endpoint override", () => {
     expect(url).toBe(
       "https://ghe.example.com/api/v3/repos/acme/cfg/contents/default.json?ref=HEAD",
     );
+  });
+});
+
+describe("fetchExternalPreset — auth failures (401/403)", () => {
+  beforeEach(() => vi.unstubAllEnvs());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("reports 'none (tried …)' credential source when no GitHub token is set", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "");
+    vi.stubEnv("RENOVATE_TOKEN", "");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        makeResponse({ message: "Requires authentication" }, {
+          status: 401,
+          statusText: "Unauthorized",
+        }),
+      );
+    const result = await fetchExternalPreset(parsePreset("github>acme/cfg"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/HTTP 401 when fetching github>acme\/cfg/);
+      expect(result.reason).toMatch(
+        /URL:\s+https:\/\/api\.github\.com\/repos\/acme\/cfg\/contents\/default\.json\?ref=HEAD/,
+      );
+      expect(result.reason).toMatch(
+        /Credential:\s+none \(tried GITHUB_TOKEN, RENOVATE_TOKEN\)/,
+      );
+      expect(result.reason).toMatch(/Response:\s+.*Requires authentication/);
+    }
+  });
+
+  it("names the specific env var that supplied the GitHub token", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "ghp_secret_value");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(makeResponse("Bad credentials", { status: 401, statusText: "Unauthorized" }));
+    const result = await fetchExternalPreset(parsePreset("github>acme/cfg"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/Credential:\s+GITHUB_TOKEN \(present\)/);
+      expect(result.reason).not.toMatch(/ghp_secret_value/);
+    }
+  });
+
+  it("names RENOVATE_TOKEN when it supplied the GitHub token (GITHUB_TOKEN unset)", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "");
+    vi.stubEnv("RENOVATE_TOKEN", "rnv_secret_value");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(makeResponse("Bad credentials", { status: 401, statusText: "Unauthorized" }));
+    const result = await fetchExternalPreset(parsePreset("github>acme/cfg"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/Credential:\s+RENOVATE_TOKEN \(present\)/);
+      expect(result.reason).not.toMatch(/rnv_secret_value/);
+    }
+  });
+
+  it("includes JSON response body verbatim on a GitLab 401", async () => {
+    vi.stubEnv("GITLAB_TOKEN", "glpat_secret");
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      makeResponse(
+        { message: "401 Unauthorized" },
+        { status: 401, statusText: "Unauthorized" },
+      ),
+    );
+    const result = await fetchExternalPreset(parsePreset("gitlab>foo/bar"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/HTTP 401 when fetching gitlab>foo\/bar/);
+      expect(result.reason).toMatch(
+        /URL:\s+https:\/\/gitlab\.com\/api\/v4\/projects\/foo%2Fbar\/repository\/files\/default\.json\/raw\?ref=HEAD/,
+      );
+      expect(result.reason).toMatch(/Credential:\s+GITLAB_TOKEN \(present\)/);
+      expect(result.reason).toMatch(/Response:\s+\{"message":"401 Unauthorized"\}/);
+      expect(result.reason).not.toMatch(/glpat_secret/);
+    }
+  });
+
+  it("omits the Response line when the body is empty", async () => {
+    vi.stubEnv("GITLAB_TOKEN", "glpat_secret");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(makeResponse("", { status: 401, statusText: "Unauthorized" }));
+    const result = await fetchExternalPreset(parsePreset("gitlab>foo/bar"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/HTTP 401 when fetching gitlab>foo\/bar/);
+      expect(result.reason).toMatch(/Credential:\s+GITLAB_TOKEN \(present\)/);
+      expect(result.reason).not.toMatch(/Response:/);
+    }
+  });
+
+  it("enriches a non-rate-limit GitHub 403 with credential and URL context", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "ghp_secret");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        makeResponse("Resource not accessible by integration", {
+          status: 403,
+          statusText: "Forbidden",
+        }),
+      );
+    const result = await fetchExternalPreset(parsePreset("github>acme/cfg"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/HTTP 403 when fetching github>acme\/cfg/);
+      expect(result.reason).toMatch(/Credential:\s+GITHUB_TOKEN \(present\)/);
+      expect(result.reason).toMatch(/Response:\s+Resource not accessible by integration/);
+      expect(result.reason).not.toMatch(/ghp_secret/);
+      expect(result.reason).not.toMatch(/rate limit/i);
+    }
+  });
+
+  it("leaves the rate-limit message untouched on a GitHub 403 with X-RateLimit-Remaining: 0", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "ghp_secret");
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      makeResponse(
+        { message: "API rate limit exceeded" },
+        {
+          status: 403,
+          statusText: "Forbidden",
+          headers: { "X-RateLimit-Remaining": "0" },
+        },
+      ),
+    );
+    const result = await fetchExternalPreset(parsePreset("github>acme/cfg"), { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/GitHub API rate limit exceeded/);
+      expect(result.reason).not.toMatch(/Credential:/);
+      expect(result.reason).not.toMatch(/^\s+URL:/m);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- On a 401 or non-rate-limit 403 from `fetchGitHub` / `fetchGitLab`, the error now includes: request URL, which env var supplied the credential (name only, never the value) or that none was set (and which vars were tried), and the response body when present.
- Rate-limited 403 (GitHub) and 429 (GitLab) still use the existing rate-limit messaging untouched.
- Token values are never echoed — only env var names.

Closes #31.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (145/145 passing, including 7 new cases covering: no token / GITHUB_TOKEN present / RENOVATE_TOKEN fallback / GitLab 401 with JSON body / 401 with empty body / enriched non-rate-limit 403 / rate-limited 403 left alone)
- [x] Verified 2xx paths unchanged (existing cache + success tests still green)