### PR TITLE
fix(resolve_config): reject unknown preset source prefixes at parse time

### DIFF
--- a/src/lib/presetResolver.ts
+++ b/src/lib/presetResolver.ts
@@ -112,6 +112,12 @@ export interface ParsedPreset {
   subpath?: string;
   /** Optional `#ref` (branch/tag/commit) fragment. */
   ref?: string;
+  /**
+   * Set when parsing already determined the preset cannot be resolved — e.g.
+   * an unknown source prefix like `xyz>foo/bar`. `loadPresetBody` short-circuits
+   * to the unresolved list with this reason.
+   */
+  unresolvableReason?: string;
 }
 
 interface ExpandContext {
@@ -247,6 +253,11 @@ async function loadPresetBody(
   ctx: ExpandContext,
   unresolvedList: UnresolvedPreset[],
 ): Promise<Record<string, unknown> | null> {
+  if (parsed.unresolvableReason) {
+    unresolvedList.push({ preset: parsed.original, reason: parsed.unresolvableReason });
+    return null;
+  }
+
   if (!parsed.source) {
     const preset = PRESETS[parsed.key];
     if (!preset) {
@@ -348,9 +359,15 @@ function parseExternal(
   args: string[],
   sourceRaw: string,
 ): ParsedPreset {
-  const source = (KNOWN_SOURCES.has(sourceRaw as ExternalSource)
-    ? sourceRaw
-    : sourceRaw) as ExternalSource;
+  if (!KNOWN_SOURCES.has(sourceRaw as ExternalSource)) {
+    return {
+      key: original,
+      original,
+      args,
+      unresolvableReason: `Unknown preset source: ${sourceRaw}`,
+    };
+  }
+  const source = sourceRaw as ExternalSource;
 
   let spec = rest.slice(sourceRaw.length + 1);
 

--- a/test/unit/presetResolver.test.ts
+++ b/test/unit/presetResolver.test.ts
@@ -99,6 +99,16 @@ describe("resolveConfig", () => {
     expect(presetsUnresolved[0]?.reason).toMatch(/catalogue/i);
   });
 
+  it("flags an unknown source prefix with a dedicated reason", async () => {
+    const { presetsResolved, presetsUnresolved } = await resolveConfig({
+      extends: ["xyz>foo/bar"],
+    });
+    expect(presetsResolved).toEqual([]);
+    expect(presetsUnresolved).toHaveLength(1);
+    expect(presetsUnresolved[0]?.preset).toBe("xyz>foo/bar");
+    expect(presetsUnresolved[0]?.reason).toMatch(/unknown preset source: xyz/i);
+  });
+
   it("resolves siblings independently when one is unknown", async () => {
     const { resolved, presetsResolved, presetsUnresolved } = await resolveConfig({
       extends: ["default:automergeAll", "config:doesNotExist"],
@@ -175,6 +185,14 @@ describe("parsePreset", () => {
   it("treats bare names as npm presets", () => {
     const p = parsePreset("some-npm-preset");
     expect(p).toMatchObject({ source: "npm", repoPath: "some-npm-preset" });
+  });
+
+  it("flags an unknown source prefix as unresolvable without setting source", () => {
+    const p = parsePreset("xyz>foo/bar");
+    expect(p.source).toBeUndefined();
+    expect(p.repoPath).toBeUndefined();
+    expect(p.unresolvableReason).toMatch(/unknown preset source: xyz/i);
+    expect(p.original).toBe("xyz>foo/bar");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #54.

`parseExternal` in `src/lib/presetResolver.ts` had a dead ternary whose `KNOWN_SOURCES.has(...)` check had no effect — both branches returned `sourceRaw`, so any string was cast straight to `ExternalSource` and flowed downstream untyped.

This change validates the source at parse time:
- Unknown prefixes (e.g. `xyz>foo/bar`) now return a `ParsedPreset` with **no** `source` and a new `unresolvableReason: "Unknown preset source: xyz"`.
- `loadPresetBody` short-circuits such presets into `presetsUnresolved` with that reason, instead of routing them through `classifyExternalSource`'s default branch via a false type assertion.

User-visible: the `Unknown preset source: …` reason is now the single, consistent path for unknown prefixes.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run` (179 passed)
- [x] New `parsePreset` unit test asserts `xyz>foo/bar` parses as unresolvable with no `source`
- [x] New `resolveConfig` test asserts end-to-end that unknown prefixes land in `presetsUnresolved` with the "Unknown preset source: xyz" reason