### PR TITLE
fix(test-helpers): reject pending mcpSession requests on crash or timeout

### DIFF
--- a/test/helpers/mcpSession.ts
+++ b/test/helpers/mcpSession.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const SERVER_ENTRY = path.resolve(__dirname, "../../dist/index.js");
+const DEFAULT_SERVER_ENTRY = path.resolve(__dirname, "../../dist/index.js");
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const STDERR_CAP_BYTES = 64 * 1024;
 
 export interface JsonRpcRequest {
   jsonrpc: "2.0";
@@ -20,6 +22,13 @@ export interface JsonRpcResponse {
   error?: { code: number; message: string; data?: unknown };
 }
 
+export interface StartServerOptions {
+  /** Per-request wall-clock timeout in milliseconds. Default: 10_000. */
+  requestTimeoutMs?: number;
+  /** Override the script to spawn. Default: dist/index.js of this repo. */
+  serverEntry?: string;
+}
+
 export interface McpSession {
   request<T = unknown>(
     method: string,
@@ -29,29 +38,95 @@ export interface McpSession {
   close(): Promise<void>;
   readonly child: ChildProcess;
   readonly instructions: string;
+  /** Current buffered stderr from the server (capped). */
+  readonly stderr: string;
 }
 
 /**
- * Spawn dist/index.js, run the initialize handshake, and return a session you
+ * Spawn the MCP server, run the initialize handshake, and return a session you
  * can call request/notify on. The server shuts down cleanly when you call
  * close() (which ends stdin, triggering StdioServerTransport to close).
+ *
+ * Pending requests reject on wall-clock timeout, on `child error`, or on
+ * `child exit` — the rejection message includes the buffered stderr so a
+ * crashed server surfaces diagnostics instead of hanging the test.
  */
-export async function startServer(env: NodeJS.ProcessEnv = {}): Promise<McpSession> {
-  const child = spawn("node", [SERVER_ENTRY], {
+export async function startServer(
+  env: NodeJS.ProcessEnv = {},
+  options: StartServerOptions = {},
+): Promise<McpSession> {
+  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const serverEntry = options.serverEntry ?? DEFAULT_SERVER_ENTRY;
+
+  const child = spawn("node", [serverEntry], {
     stdio: ["pipe", "pipe", "pipe"],
     env: { ...process.env, ...env },
   });
 
-  const pending = new Map<number, (msg: JsonRpcResponse) => void>();
+  let stderrBuffer = "";
+  child.stderr!.setEncoding("utf8");
+  child.stderr!.on("data", (chunk: string) => {
+    stderrBuffer += chunk;
+    if (stderrBuffer.length > STDERR_CAP_BYTES) {
+      stderrBuffer = stderrBuffer.slice(stderrBuffer.length - STDERR_CAP_BYTES);
+    }
+  });
+
+  interface Pending {
+    method: string;
+    resolve: (msg: JsonRpcResponse) => void;
+    reject: (err: Error) => void;
+    timer: NodeJS.Timeout;
+  }
+  const pending = new Map<number, Pending>();
+
+  let terminated = false;
+  let terminationError: Error | null = null;
+  let closed = false;
+
+  function stderrSuffix(): string {
+    return stderrBuffer ? `\n--- server stderr ---\n${stderrBuffer.trimEnd()}` : "";
+  }
+
+  function failAllPending(err: Error) {
+    for (const p of pending.values()) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    pending.clear();
+  }
+
+  child.on("error", (err) => {
+    terminated = true;
+    terminationError = new Error(`MCP server spawn error: ${err.message}${stderrSuffix()}`);
+    failAllPending(terminationError);
+  });
+
+  child.on("exit", (code, signal) => {
+    terminated = true;
+    if (pending.size === 0) return;
+    const desc = signal ? `signal ${signal}` : `code ${code}`;
+    terminationError = new Error(
+      `MCP server exited (${desc}) with ${pending.size} pending request(s)${stderrSuffix()}`,
+    );
+    failAllPending(terminationError);
+  });
+
+  child.on("close", () => {
+    closed = true;
+  });
+
   const rl = createInterface({ input: child.stdout! });
   rl.on("line", (line) => {
     if (!line.trim()) return;
     try {
       const msg = JSON.parse(line) as JsonRpcResponse;
-      if (typeof msg.id === "number" && pending.has(msg.id)) {
-        pending.get(msg.id)!(msg);
-        pending.delete(msg.id);
-      }
+      if (typeof msg.id !== "number") return;
+      const p = pending.get(msg.id);
+      if (!p) return;
+      clearTimeout(p.timer);
+      pending.delete(msg.id);
+      p.resolve(msg);
     } catch {
       // non-JSON stdout line — ignore
     }
@@ -63,9 +138,29 @@ export async function startServer(env: NodeJS.ProcessEnv = {}): Promise<McpSessi
     method: string,
     params?: unknown,
   ): Promise<JsonRpcResponse & { result?: T }> {
+    if (terminated) {
+      return Promise.reject(
+        terminationError ??
+          new Error(`MCP server has terminated before request ${method}${stderrSuffix()}`),
+      );
+    }
     const id = nextId++;
-    return new Promise((resolve) => {
-      pending.set(id, resolve as (msg: JsonRpcResponse) => void);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(
+          new Error(
+            `MCP request ${method} (id=${id}) timed out after ${requestTimeoutMs}ms${stderrSuffix()}`,
+          ),
+        );
+      }, requestTimeoutMs);
+      timer.unref?.();
+      pending.set(id, {
+        method,
+        resolve: resolve as (msg: JsonRpcResponse) => void,
+        reject,
+        timer,
+      });
       child.stdin!.write(
         JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n",
       );
@@ -73,6 +168,7 @@ export async function startServer(env: NodeJS.ProcessEnv = {}): Promise<McpSessi
   }
 
   function notify(method: string, params?: unknown): void {
+    if (terminated) return;
     child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
   }
 
@@ -88,9 +184,18 @@ export async function startServer(env: NodeJS.ProcessEnv = {}): Promise<McpSessi
     notify,
     child,
     instructions: init.result?.instructions ?? "",
+    get stderr() {
+      return stderrBuffer;
+    },
     async close() {
-      child.stdin!.end();
+      if (closed) return;
+      try {
+        child.stdin!.end();
+      } catch {
+        // stdin may already be closed — fine.
+      }
       await new Promise<void>((resolve) => {
+        if (closed) return resolve();
         child.once("close", () => resolve());
       });
     },

--- a/test/unit/mcpSession.test.ts
+++ b/test/unit/mcpSession.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, chmod } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { startServer, type McpSession } from "../helpers/mcpSession.js";
+
+/**
+ * Exercises mcpSession's crash/hang handling. We point `serverEntry` at small
+ * fake server scripts generated on disk — no real Renovate or MCP SDK involved.
+ */
+
+let session: McpSession | undefined;
+let workDir: string | undefined;
+
+afterEach(async () => {
+  if (session) {
+    await session.close().catch(() => {});
+    session = undefined;
+  }
+  if (workDir) {
+    await rm(workDir, { recursive: true, force: true });
+    workDir = undefined;
+  }
+});
+
+async function writeFakeServer(body: string): Promise<string> {
+  workDir = await mkdtemp(path.join(tmpdir(), "rmcp-fakesrv-"));
+  const file = path.join(workDir, "server.mjs");
+  await writeFile(file, `#!/usr/bin/env node\n${body}\n`);
+  await chmod(file, 0o755);
+  return file;
+}
+
+/**
+ * A fake server that answers `initialize`, then takes an action before any
+ * follow-up request can be answered. `action` is inlined into the script.
+ */
+async function makeFakeServerAfterInit(action: string): Promise<string> {
+  return writeFakeServer(`
+let buf = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buf += chunk;
+  let idx;
+  while ((idx = buf.indexOf("\\n")) >= 0) {
+    const line = buf.slice(0, idx);
+    buf = buf.slice(idx + 1);
+    if (!line.trim()) continue;
+    let msg;
+    try { msg = JSON.parse(line); } catch { continue; }
+    if (msg.method === "initialize") {
+      process.stdout.write(JSON.stringify({
+        jsonrpc: "2.0",
+        id: msg.id,
+        result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "fake", version: "0" } },
+      }) + "\\n");
+    } else if (msg.method === "notifications/initialized") {
+      ${action}
+    }
+    // Any other request id is intentionally ignored so the client's request hangs
+    // until its wall-clock timeout or an exit event fires.
+  }
+});
+`);
+}
+
+describe("mcpSession request() failure modes", () => {
+  it("rejects pending request when the server exits after initialize", async () => {
+    const serverEntry = await makeFakeServerAfterInit(`
+      process.stderr.write("fake server crashing for test\\n");
+      process.exit(3);
+    `);
+    session = await startServer({}, { serverEntry, requestTimeoutMs: 5_000 });
+
+    await expect(session.request("tools/list")).rejects.toThrow(/code 3/);
+  });
+
+  it("surfaces buffered stderr in the rejection message", async () => {
+    const serverEntry = await makeFakeServerAfterInit(`
+      process.stderr.write("boom: the thing went wrong\\n");
+      process.exit(7);
+    `);
+    session = await startServer({}, { serverEntry, requestTimeoutMs: 5_000 });
+
+    await expect(session.request("tools/list")).rejects.toThrow(/boom: the thing went wrong/);
+  });
+
+  it("rejects pending request when the server hangs past the wall-clock timeout", async () => {
+    // Server accepts initialize but never responds to any follow-up request.
+    const serverEntry = await makeFakeServerAfterInit(`
+      /* keep the process alive but silent */
+    `);
+    session = await startServer({}, { serverEntry, requestTimeoutMs: 200 });
+
+    await expect(session.request("tools/list")).rejects.toThrow(/timed out after 200ms/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #55. `test/helpers/mcpSession.ts` `request()` never rejected — pending promises leaked when the server child crashed or hung, so a crashed server blocked the suite until vitest's global timeout (and swallowed the stderr diagnostics).

- Wall-clock timeout on `request()` (default 10s, configurable via `startServer(env, { requestTimeoutMs })`).
- Reject every pending request on child `error`/`exit`, with exit code or signal in the message.
- Capture server stderr (capped at 64KB) and append it to rejection messages so a crashed server self-diagnoses.
- Add a `serverEntry` option so tests can point the helper at fake servers; expose `session.stderr`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` green (180/180, +3 new)
- [x] New `test/unit/mcpSession.test.ts` covers three failure modes with inline fake servers: exit-after-initialize → rejects with exit code; stderr → surfaced in rejection; hung server → rejects at wall-clock timeout