### PR TITLE
docs(ci): document why Renovate CLI is not installed in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,14 @@
 name: CI
 
+# NOTE: This workflow deliberately does NOT install the `renovate` CLI.
+# The `validate_config` and `dry_run` tools shell out to Renovate (see
+# src/lib/renovateCli.ts) and therefore are NOT exercised end-to-end here.
+# Integration tests for those paths use fake binaries via
+# RENOVATE_BIN / RENOVATE_CONFIG_VALIDATOR_BIN instead (see
+# test/helpers/mcpSession.ts). Rationale and the broader design decision
+# live in CLAUDE.md ("Integration tests use stdio + fake binaries").
+# If you add a job that does install Renovate, update CLAUDE.md too.
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- Adds a comment block at the top of `.github/workflows/ci.yml` explaining that `validate_config` and `dry_run` are deliberately not exercised end-to-end in CI.
- Points readers at `CLAUDE.md` and the fake-binary pattern used by integration tests (via `RENOVATE_BIN` / `RENOVATE_CONFIG_VALIDATOR_BIN`).
- Minimal fix (option 1) from #65; the second-job follow-up (option 2) remains out of scope.

## Test plan
- [x] `ci.yml` still parses — change is comment-only above `on:`.
- [x] Comment names the two affected tools and links back to `CLAUDE.md`.
- [ ] CI run on this PR still green.

Closes #65