### PR TITLE
fix(write_config): clean up tmp file when final rename fails

### DIFF
--- a/src/tools/writeConfig.ts
+++ b/src/tools/writeConfig.ts
@@ -65,34 +65,55 @@ export function registerWriteConfig(server: McpServer): void {
       await fs.mkdir(path.dirname(target), { recursive: true });
       await fs.writeFile(tmp, payload);
 
-      let valid = false;
-      let validationOutput = "";
-      let validatorMissing = false;
       try {
-        const bin = resolveRenovateTool("renovate-config-validator");
-        const v = await run(bin, [tmp], { timeoutMs: 30_000 });
-        validationOutput = (v.stdout + v.stderr).trim();
-        valid = v.exitCode === 0;
-      } catch (err) {
-        validatorMissing = true;
-        validationOutput = formatMissingBinaryError("renovate-config-validator", err as Error);
-      }
+        let valid = false;
+        let validationOutput = "";
+        let validatorMissing = false;
+        try {
+          const bin = resolveRenovateTool("renovate-config-validator");
+          const v = await run(bin, [tmp], { timeoutMs: 30_000 });
+          validationOutput = (v.stdout + v.stderr).trim();
+          valid = v.exitCode === 0;
+        } catch (err) {
+          validatorMissing = true;
+          validationOutput = formatMissingBinaryError("renovate-config-validator", err as Error);
+        }
 
-      if (!valid && !force) {
-        await fs.unlink(tmp).catch(() => undefined);
+        if (!valid && !force) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    wrote: false,
+                    reason: validatorMissing ? "validator-unavailable" : "validation-failed",
+                    validationOutput,
+                    hint: validatorMissing
+                      ? "Install renovate-config-validator (or set RENOVATE_CONFIG_VALIDATOR_BIN), then retry. Pass force=true to skip validation entirely."
+                      : "Pass force=true to write anyway.",
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        }
+
+        await fs.rename(tmp, target);
         return {
-          isError: true,
           content: [
             {
               type: "text",
               text: JSON.stringify(
                 {
-                  wrote: false,
-                  reason: validatorMissing ? "validator-unavailable" : "validation-failed",
-                  validationOutput,
-                  hint: validatorMissing
-                    ? "Install renovate-config-validator (or set RENOVATE_CONFIG_VALIDATOR_BIN), then retry. Pass force=true to skip validation entirely."
-                    : "Pass force=true to write anyway.",
+                  wrote: true,
+                  path: rel,
+                  bytes: payload.length,
+                  valid,
+                  validationOutput: valid ? undefined : validationOutput,
                 },
                 null,
                 2,
@@ -100,27 +121,11 @@ export function registerWriteConfig(server: McpServer): void {
             },
           ],
         };
+      } finally {
+        // No-op when rename already moved tmp (ENOENT); otherwise cleans up on
+        // validation failure or a mid-flight rename error (see #57).
+        await fs.unlink(tmp).catch(() => undefined);
       }
-
-      await fs.rename(tmp, target);
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(
-              {
-                wrote: true,
-                path: rel,
-                bytes: payload.length,
-                valid,
-                validationOutput: valid ? undefined : validationOutput,
-              },
-              null,
-              2,
-            ),
-          },
-        ],
-      };
     },
   );
 }

--- a/test/integration/writeConfig.test.ts
+++ b/test/integration/writeConfig.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, writeFile, readFile, readdir, chmod, symlink } from "node:fs/promises";
+import {
+  mkdtemp,
+  mkdir,
+  rm,
+  writeFile,
+  readFile,
+  readdir,
+  chmod,
+  symlink,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { startServer, type McpSession } from "../helpers/mcpSession.js";
@@ -114,6 +123,31 @@ describe("write_config", () => {
     } finally {
       await rm(outside, { recursive: true, force: true });
     }
+  });
+
+  it("cleans up the tmp file when the final rename fails (issue #57)", async () => {
+    // Simulate a rename failure by pre-creating a non-empty directory at the
+    // target path — fs.rename(tmp, target) fails with ENOTEMPTY / EISDIR on
+    // POSIX. Before the fix, the .renovate-mcp-tmp file was left behind.
+    const validator = await makeFakeValidator(repo, "fake-pass.mjs", 0);
+    session = await startServer({ RENOVATE_CONFIG_VALIDATOR_BIN: validator });
+
+    const targetAsDir = path.join(repo, "renovate.json");
+    await mkdir(targetAsDir);
+    await writeFile(path.join(targetAsDir, "placeholder"), "x");
+
+    await session
+      .request("tools/call", {
+        name: "write_config",
+        arguments: {
+          repoPath: repo,
+          config: { extends: ["config:recommended"] },
+        },
+      })
+      .catch(() => undefined);
+
+    const files = await readdir(repo);
+    expect(files.some((f) => f.endsWith(".renovate-mcp-tmp"))).toBe(false);
   });
 
   it("writes anyway when force=true and validation fails", async () => {


### PR DESCRIPTION
## Summary

- Wraps the validate→rename flow in `write_config` in a `try { … } finally { await fs.unlink(tmp).catch(() => undefined); }` so the `.renovate-mcp-tmp` staging file is removed on every exit path, including the previously-uncovered case where `fs.rename(tmp, target)` throws (cross-device rename, parent dir vanished, permission change mid-flight).
- Drops the now-redundant explicit `fs.unlink(tmp)` from the validation-failure branch — the `finally` handles it uniformly.
- Adds a regression integration test that pre-creates a non-empty directory at the target path to force `fs.rename` to fail, then asserts no `.renovate-mcp-tmp` file remains in the repo.

Closes #57.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 185/185 passing, including the new `cleans up the tmp file when the final rename fails (issue #57)` case
- [x] Manually traced all three exit paths:
  - Success → rename moves tmp → finally's unlink hits ENOENT → swallowed
  - Validation failure (no force) → finally unlinks tmp
  - Rename throws → finally unlinks tmp, error propagates