### PR TITLE
perf(hostRulesConfig): scrub secrets in a single regex pass

### DIFF
--- a/src/lib/hostRulesConfig.ts
+++ b/src/lib/hostRulesConfig.ts
@@ -44,16 +44,23 @@ export function collectSecrets(hostRules: HostRule[]): string[] {
   return [...out];
 }
 
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
  * Replace every literal occurrence of any secret in `text` with `[REDACTED]`.
  * No-op when `secrets` is empty.
  */
 export function scrubSecrets(text: string, secrets: string[]): string {
-  if (!secrets.length) return text;
-  let result = text;
-  for (const secret of secrets) {
-    if (!secret) continue;
-    result = result.split(secret).join("[REDACTED]");
-  }
-  return result;
+  // Sort by length descending so that when one secret is a substring of
+  // another, the longer one wins the greedy regex alternation instead of
+  // being partially chewed up by the shorter one.
+  const alternatives = secrets
+    .filter((s) => s.length > 0)
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegex);
+  if (!alternatives.length) return text;
+  const pattern = new RegExp(alternatives.join("|"), "g");
+  return text.replace(pattern, "[REDACTED]");
 }

--- a/test/unit/hostRulesConfig.test.ts
+++ b/test/unit/hostRulesConfig.test.ts
@@ -104,4 +104,18 @@ describe("scrubSecrets", () => {
     const input = "abcdef";
     expect(scrubSecrets(input, [""])).toBe(input);
   });
+
+  it("prefers the longer secret when one is a substring of another", () => {
+    // "tok" appears inside "tok-long". Without a length-desc sort, the shorter
+    // secret could chew a prefix out of the longer one and leave a stray
+    // suffix behind.
+    const out = scrubSecrets("value=tok-long and also tok alone", ["tok", "tok-long"]);
+    expect(out).toBe("value=[REDACTED] and also [REDACTED] alone");
+  });
+
+  it("treats regex metacharacters in secrets as literal text", () => {
+    const secret = "a.b*c+?|$(d)";
+    const out = scrubSecrets(`before ${secret} after`, [secret]);
+    expect(out).toBe("before [REDACTED] after");
+  });
 });


### PR DESCRIPTION
## Summary

- Replace per-secret `split/join` in `scrubSecrets` with a single alternation regex — one pass, one allocation.
- Sort alternatives by length descending so when one secret is a substring of another, the longer one wins the greedy match (avoids a short secret partially chewing through a longer one's replacement).
- Escape regex metacharacters in each secret so values containing e.g. `.`, `\$`, or `|` are treated as literal text.

Closes #63.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 14 files / 186 tests pass
- [x] New unit tests added for the overlapping-secrets and regex-metacharacter cases