### PR TITLE
test(lint_config): cover JSON5 configPath parse path

### DIFF
--- a/test/integration/mcpServer.test.ts
+++ b/test/integration/mcpServer.test.ts
@@ -228,6 +228,58 @@ describe("lint_config end-to-end", () => {
     });
   });
 
+  it("lints a .renovaterc.json5 file with JSON5-only syntax via configPath", async () => {
+    const configPath = path.join(repo, ".renovaterc.json5");
+    await writeFile(
+      configPath,
+      [
+        "// Renovate config authored in JSON5",
+        "{",
+        "  extends: ['config:recommended'],",
+        "  packageRules: [",
+        "    {",
+        "      // unwrapped regex — should trip the linter",
+        "      matchDepNames: ['foo.+'],",
+        "    },",
+        "  ],",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    session = await startServer();
+    const res = await session.request<{
+      isError?: boolean;
+      content: Array<{ type: string; text: string }>;
+    }>("tools/call", {
+      name: "lint_config",
+      arguments: { configPath },
+    });
+    expect(res.result?.isError).toBeFalsy();
+    const parsed = JSON.parse(res.result?.content[0]?.text ?? "{}");
+    expect(parsed.clean).toBe(false);
+    expect(parsed.findings[0]).toMatchObject({
+      ruleId: "unwrapped-regex",
+      path: "packageRules[0].matchDepNames[0]",
+    });
+  });
+
+  it("reports isError with a helpful message for malformed JSON5", async () => {
+    const configPath = path.join(repo, ".renovaterc.json5");
+    await writeFile(configPath, "{ extends: ['config:recommended', }");
+    session = await startServer();
+    const res = await session.request<{
+      isError?: boolean;
+      content: Array<{ type: string; text: string }>;
+    }>("tools/call", {
+      name: "lint_config",
+      arguments: { configPath },
+    });
+    expect(res.result?.isError).toBe(true);
+    expect(res.result?.content[0]?.text).toContain("Failed to read or parse config at");
+    expect(res.result?.content[0]?.text).toContain(configPath);
+    expect(res.result?.content[0]?.text).toContain("JSON5:");
+  });
+
   it("reports isError when neither input is supplied", async () => {
     session = await startServer();
     const res = await session.request<{


### PR DESCRIPTION
## Summary
- Add a happy-path integration test loading `.renovaterc.json5` with JSON5-only syntax (line comment, unquoted keys, trailing commas) and assert the linter runs on the parsed result.
- Add a malformed-JSON5 test asserting `isError: true` and a `JSON5:`-prefixed error message — proving the JSON5 branch in `lintConfig.ts` was actually taken, not JSON.parse.

Closes #60.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 186 passed
- [x] Temporarily collapsed the JSON5 branch in `src/tools/lintConfig.ts` to `JSON.parse(raw)` and confirmed both new tests fail loudly, then restored it.