### PR TITLE
refactor(errors): add toMessage/toError helpers; drop unsafe as-Error casts

### DIFF
--- a/src/lib/customManagerPreview.ts
+++ b/src/lib/customManagerPreview.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { Worker } from "node:worker_threads";
 import ignore, { type Ignore } from "ignore";
+import { toMessage } from "./errors.js";
 
 export interface CustomManager {
   customType: string;
@@ -150,7 +151,7 @@ export async function previewCustomManager(
     try {
       stat = await fs.stat(abs);
     } catch (err) {
-      warnings.push(`Could not stat ${rel}: ${(err as Error).message}`);
+      warnings.push(`Could not stat ${rel}: ${toMessage(err)}`);
       continue;
     }
     if (stat.size > maxFileBytes) {
@@ -163,7 +164,7 @@ export async function previewCustomManager(
     try {
       content = await fs.readFile(abs, "utf8");
     } catch (err) {
-      warnings.push(`Could not read ${rel}: ${(err as Error).message}`);
+      warnings.push(`Could not read ${rel}: ${toMessage(err)}`);
       continue;
     }
 
@@ -243,7 +244,7 @@ function validateRegex(source: string): void {
   try {
     new RegExp(source);
   } catch (err) {
-    throw new Error(`Invalid regex /${source}/: ${(err as Error).message}`);
+    throw new Error(`Invalid regex /${source}/: ${toMessage(err)}`);
   }
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,16 @@
+export function toMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === "string") return e;
+  try {
+    const json = JSON.stringify(e);
+    if (json !== undefined) return json;
+  } catch {
+    // fall through to String() below
+  }
+  return String(e);
+}
+
+export function toError(e: unknown): Error {
+  if (e instanceof Error) return e;
+  return new Error(toMessage(e));
+}

--- a/src/lib/externalPresetFetcher.ts
+++ b/src/lib/externalPresetFetcher.ts
@@ -1,4 +1,5 @@
 import { classifyExternalSource, type ParsedPreset } from "./presetResolver.js";
+import { toMessage } from "./errors.js";
 
 export interface FetchOptions {
   timeoutMs?: number;
@@ -211,12 +212,11 @@ async function fetchJson(
     } catch (e) {
       return {
         ok: false,
-        reason: `Preset body for ${presetName} is not valid JSON: ${(e as Error).message}`,
+        reason: `Preset body for ${presetName} is not valid JSON: ${toMessage(e)}`,
       };
     }
   } catch (e) {
-    const err = e as Error;
-    if (err.name === "AbortError") {
+    if (e instanceof Error && e.name === "AbortError") {
       return {
         ok: false,
         reason: `Timed out after ${timeoutMs}ms fetching ${presetName}`,
@@ -224,7 +224,7 @@ async function fetchJson(
     }
     return {
       ok: false,
-      reason: `Network error fetching ${presetName}: ${err.message}`,
+      reason: `Network error fetching ${presetName}: ${toMessage(e)}`,
     };
   } finally {
     clearTimeout(timer);

--- a/src/lib/renovateCli.ts
+++ b/src/lib/renovateCli.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { toMessage } from "./errors.js";
 
 export interface RunResult {
   stdout: string;
@@ -84,11 +85,11 @@ export function resolveRenovateTool(tool: "renovate" | "renovate-config-validato
  */
 export function formatMissingBinaryError(
   tool: "renovate" | "renovate-config-validator",
-  cause: Error,
+  cause: unknown,
 ): string {
   const envKey = tool === "renovate" ? "RENOVATE_BIN" : "RENOVATE_CONFIG_VALIDATOR_BIN";
   return [
-    `Failed to run \`${tool}\`: ${cause.message}.`,
+    `Failed to run \`${tool}\`: ${toMessage(cause)}.`,
     `Install Renovate globally with \`npm i -g renovate\`, or set ${envKey} to point at an existing binary.`,
     "Call the `check_setup` tool for a full diagnostic.",
   ].join(" ");

--- a/src/lib/setupCheck.ts
+++ b/src/lib/setupCheck.ts
@@ -1,4 +1,5 @@
 import { run, resolveRenovateTool } from "./renovateCli.js";
+import { toMessage } from "./errors.js";
 
 export type RenovateBinary = "renovate" | "renovate-config-validator";
 
@@ -47,7 +48,7 @@ async function checkBinary(tool: RenovateBinary): Promise<BinaryStatus> {
       tool,
       command,
       found: false,
-      error: (err as Error).message,
+      error: toMessage(err),
     };
   }
 }

--- a/src/tools/dryRun.ts
+++ b/src/tools/dryRun.ts
@@ -124,7 +124,7 @@ export function registerDryRun(server: McpServer): void {
             {
               type: "text",
               text: scrubSecrets(
-                formatMissingBinaryError("renovate", err as Error),
+                formatMissingBinaryError("renovate", err),
                 secrets,
               ),
             },

--- a/src/tools/lintConfig.ts
+++ b/src/tools/lintConfig.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import JSON5 from "json5";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { lintConfig } from "../lib/configLinter.js";
+import { toMessage } from "../lib/errors.js";
 
 export function registerLintConfig(server: McpServer): void {
   server.registerTool(
@@ -48,7 +49,7 @@ export function registerLintConfig(server: McpServer): void {
             content: [
               {
                 type: "text",
-                text: `Failed to read or parse config at ${configPath}: ${(err as Error).message}`,
+                text: `Failed to read or parse config at ${configPath}: ${toMessage(err)}`,
               },
             ],
           };

--- a/src/tools/previewCustomManager.ts
+++ b/src/tools/previewCustomManager.ts
@@ -4,6 +4,7 @@ import {
   previewCustomManager,
   type CustomManager,
 } from "../lib/customManagerPreview.js";
+import { toMessage } from "../lib/errors.js";
 
 const managerSchema = z
   .object({
@@ -128,7 +129,7 @@ export function registerPreviewCustomManager(server: McpServer): void {
         return {
           isError: true,
           content: [
-            { type: "text", text: (err as Error).message },
+            { type: "text", text: toMessage(err) },
           ],
         };
       }

--- a/src/tools/validateConfig.ts
+++ b/src/tools/validateConfig.ts
@@ -72,7 +72,7 @@ export function registerValidateConfig(server: McpServer): void {
           content: [
             {
               type: "text",
-              text: formatMissingBinaryError("renovate-config-validator", err as Error),
+              text: formatMissingBinaryError("renovate-config-validator", err),
             },
           ],
         };

--- a/src/tools/writeConfig.ts
+++ b/src/tools/writeConfig.ts
@@ -76,7 +76,7 @@ export function registerWriteConfig(server: McpServer): void {
           valid = v.exitCode === 0;
         } catch (err) {
           validatorMissing = true;
-          validationOutput = formatMissingBinaryError("renovate-config-validator", err as Error);
+          validationOutput = formatMissingBinaryError("renovate-config-validator", err);
         }
 
         if (!valid && !force) {

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { toMessage, toError } from "../../src/lib/errors.js";
+
+describe("toMessage", () => {
+  it("extracts message from Error instances", () => {
+    expect(toMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("returns strings as-is", () => {
+    expect(toMessage("nope")).toBe("nope");
+  });
+
+  it("JSON-stringifies plain objects", () => {
+    expect(toMessage({ code: "ENOENT" })).toBe('{"code":"ENOENT"}');
+  });
+
+  it("handles values that are not JSON-serializable (circular)", () => {
+    const obj: Record<string, unknown> = {};
+    obj.self = obj;
+    expect(toMessage(obj)).toBe("[object Object]");
+  });
+
+  it("handles undefined and null without crashing", () => {
+    expect(toMessage(undefined)).toBe("undefined");
+    expect(toMessage(null)).toBe("null");
+  });
+
+  it("extracts message from Error subclasses", () => {
+    class MyErr extends Error {
+      constructor() {
+        super("subclass-msg");
+        this.name = "MyErr";
+      }
+    }
+    expect(toMessage(new MyErr())).toBe("subclass-msg");
+  });
+});
+
+describe("toError", () => {
+  it("returns Error instances unchanged", () => {
+    const e = new Error("x");
+    expect(toError(e)).toBe(e);
+  });
+
+  it("wraps non-Error values into Error with toMessage() text", () => {
+    const wrapped = toError("oops");
+    expect(wrapped).toBeInstanceOf(Error);
+    expect(wrapped.message).toBe("oops");
+  });
+
+  it("wraps plain objects via JSON.stringify", () => {
+    expect(toError({ a: 1 }).message).toBe('{"a":1}');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/lib/errors.ts` with `toMessage(e: unknown): string` and `toError(e: unknown): Error` helpers.
- Replaces every `(err as Error).message` / `(e as Error).message` site in `src/` with `toMessage(err)`.
- Updates `formatMissingBinaryError` to take `unknown` and call `toMessage` internally, so all three shell-out tools (`validate_config`, `dry_run`, `write_config`) drop their casts too.
- `externalPresetFetcher`'s `AbortError` branch now narrows via `instanceof Error` instead of a blind cast, matching the brittleness the issue flagged.

## Motivation
`(err as Error).message` lies silently when the caught value isn't an `Error` — custom thrown non-Error values, `fetch` `TypeError` wrappers with `.cause` chains, and older-Node `AbortError` subclasses all hit the bad path. The resulting `undefined.message` secondary crash buries the real cause.

## Verify
```
grep -rn '(err as Error)' src/   # 0 hits
grep -rn '(e as Error)' src/     # 0 hits
grep -rn 'as Error' src/         # 0 hits
```

## Test plan
- [x] `npm run typecheck` passes.
- [x] New `test/unit/errors.test.ts` covers `Error`, `Error` subclasses, strings, plain objects, circular objects (`JSON.stringify` throws), `undefined`, and `null`.
- [x] Existing unit tests for all touched files pass (`externalPresetFetcher`, `customManagerPreview`, `setupCheck`, `renovateCli`, `configLinter`).
- [x] Integration tests pass when run individually; pre-existing `initialize` timeout flakiness under parallel stdio load is unchanged by this PR.

Closes #64.