### PR TITLE
test(integration): cover check_setup, read_config, validate_config MCP response shape

### DIFF
--- a/test/integration/checkSetup.test.ts
+++ b/test/integration/checkSetup.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { startServer, type McpSession } from "../helpers/mcpSession.js";
+
+/**
+ * check_setup never shells out to the real Renovate CLI in tests — CI doesn't
+ * install it. We stub both binaries with `/bin/echo` (exits 0 on --version) for
+ * the happy path, or point them at nonexistent paths for the failure path, and
+ * verify the MCP response shape end-to-end.
+ */
+
+let session: McpSession;
+
+afterEach(async () => {
+  if (session) await session.close();
+});
+
+// The tool response is `${summary}\n\n${JSON.stringify(status, null, 2)}` —
+// the summary itself contains blank lines (hints block), so extract the
+// trailing JSON by finding the last `{` that starts a line.
+function extractTrailingJson(text: string): string {
+  const idx = text.lastIndexOf("\n{");
+  if (idx === -1) throw new Error(`no JSON payload in response:\n${text}`);
+  return text.slice(idx + 1);
+}
+
+describe("check_setup", () => {
+  it("reports ok with no isError when both binaries are discoverable", async () => {
+    session = await startServer(
+      {
+        RENOVATE_BIN: "/bin/echo",
+        RENOVATE_CONFIG_VALIDATOR_BIN: "/bin/echo",
+      },
+      { requestTimeoutMs: 30_000 },
+    );
+
+    const res = await session.request<{
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    }>("tools/call", { name: "check_setup", arguments: {} });
+
+    expect(res.result?.isError).toBeFalsy();
+
+    const text = res.result!.content[0]!.text;
+    expect(text).toContain("Node: v");
+    expect(text).toContain("renovate:");
+    expect(text).toContain("renovate-config-validator:");
+
+    const status = JSON.parse(extractTrailingJson(text)) as {
+      ok: boolean;
+      renovate: { found: boolean };
+      renovateConfigValidator: { found: boolean };
+      envOverrides: Record<string, string>;
+    };
+    expect(status.ok).toBe(true);
+    expect(status.renovate.found).toBe(true);
+    expect(status.renovateConfigValidator.found).toBe(true);
+    expect(status.envOverrides).toMatchObject({
+      RENOVATE_BIN: "/bin/echo",
+      RENOVATE_CONFIG_VALIDATOR_BIN: "/bin/echo",
+    });
+  });
+
+  it("returns isError with MISSING markers when both binaries are absent", async () => {
+    session = await startServer(
+      {
+        RENOVATE_BIN: "/nonexistent/path/to/renovate",
+        RENOVATE_CONFIG_VALIDATOR_BIN: "/nonexistent/path/to/validator",
+        // Keep the startup banner out of the way so the instructions check in
+        // mcpServer.test.ts still passes; it has no effect on check_setup
+        // itself.
+        RENOVATE_MCP_REQUIRE_CLI: "false",
+      },
+      { requestTimeoutMs: 30_000 },
+    );
+
+    const res = await session.request<{
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    }>("tools/call", { name: "check_setup", arguments: {} });
+
+    expect(res.result?.isError).toBe(true);
+
+    const text = res.result!.content[0]!.text;
+    expect(text).toContain("MISSING");
+    expect(text).toContain("Hints:");
+
+    const status = JSON.parse(extractTrailingJson(text)) as {
+      ok: boolean;
+      renovate: { found: boolean };
+      renovateConfigValidator: { found: boolean };
+      hints: string[];
+    };
+    expect(status.ok).toBe(false);
+    expect(status.renovate.found).toBe(false);
+    expect(status.renovateConfigValidator.found).toBe(false);
+    expect(status.hints.length).toBe(2);
+  });
+});

--- a/test/integration/readConfig.test.ts
+++ b/test/integration/readConfig.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { startServer, type McpSession } from "../helpers/mcpSession.js";
+
+/**
+ * The happy path for renovate.json and the missing-config path are already
+ * covered by mcpServer.test.ts. This file adds the package.json#renovate and
+ * JSON5 paths that were previously only exercised at the unit level — the
+ * issue #59 audit flagged these as untested through the real MCP response
+ * layer.
+ *
+ * All tests here use the default env, so we share one server across the whole
+ * file to keep concurrent startup pressure low when the full suite runs.
+ */
+
+let session: McpSession;
+let repo: string;
+
+beforeAll(async () => {
+  session = await startServer({}, { requestTimeoutMs: 30_000 });
+});
+
+afterAll(async () => {
+  if (session) await session.close();
+});
+
+beforeEach(async () => {
+  repo = await mkdtemp(path.join(tmpdir(), "rmcp-read-"));
+});
+
+afterEach(async () => {
+  await rm(repo, { recursive: true, force: true });
+});
+
+async function readConfig(repoPath: string) {
+  const res = await session.request<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>("tools/call", { name: "read_config", arguments: { repoPath } });
+  return res.result!;
+}
+
+describe("read_config", () => {
+  it("returns the renovate field from package.json when no dedicated file exists", async () => {
+    await writeFile(
+      path.join(repo, "package.json"),
+      JSON.stringify({
+        name: "example",
+        renovate: { extends: ["config:recommended"], schedule: ["weekly"] },
+      }),
+    );
+
+    const result = await readConfig(repo);
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.path).toBe("package.json");
+    expect(parsed.format).toBe("package.json");
+    expect(parsed.config).toMatchObject({
+      extends: ["config:recommended"],
+      schedule: ["weekly"],
+    });
+  });
+
+  it("treats a non-object renovate field in package.json as no config found", async () => {
+    // Renovate only recognises package.json#renovate when it's an object.
+    // An array / string / number is silently ignored — read_config should
+    // report the config as missing rather than surfacing a parse error.
+    await writeFile(
+      path.join(repo, "package.json"),
+      JSON.stringify({ name: "example", renovate: ["not", "an", "object"] }),
+    );
+
+    const result = await readConfig(repo);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]!.text).toContain("No Renovate configuration found");
+  });
+
+  it("parses a renovate.json5 config with comments and trailing commas", async () => {
+    await writeFile(
+      path.join(repo, "renovate.json5"),
+      [
+        "// Renovate config authored in JSON5",
+        "{",
+        "  extends: ['config:recommended'],",
+        "  schedule: ['before 6am on monday',],",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    const result = await readConfig(repo);
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.path).toBe("renovate.json5");
+    expect(parsed.format).toBe("json5");
+    expect(parsed.config).toMatchObject({
+      extends: ["config:recommended"],
+      schedule: ["before 6am on monday"],
+    });
+  });
+
+  it("prefers renovate.json over .github/renovate.json when both exist", async () => {
+    await mkdir(path.join(repo, ".github"));
+    await writeFile(
+      path.join(repo, ".github", "renovate.json"),
+      JSON.stringify({ extends: ["config:base"] }),
+    );
+    await writeFile(
+      path.join(repo, "renovate.json"),
+      JSON.stringify({ extends: ["config:recommended"] }),
+    );
+
+    const result = await readConfig(repo);
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.path).toBe("renovate.json");
+    expect(parsed.config).toMatchObject({ extends: ["config:recommended"] });
+  });
+});

--- a/test/integration/validateConfig.test.ts
+++ b/test/integration/validateConfig.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, chmod } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { startServer, type McpSession } from "../helpers/mcpSession.js";
+
+/**
+ * validate_config shells out to renovate-config-validator; CI does not install
+ * it. We stub the binary with tiny fake Node scripts that exit 0 (valid) or 1
+ * (invalid), then check the MCP response shape through the real stdio +
+ * handshake path.
+ */
+
+let repo: string;
+let session: McpSession;
+
+beforeEach(async () => {
+  repo = await mkdtemp(path.join(tmpdir(), "rmcp-validate-"));
+});
+
+afterEach(async () => {
+  if (session) await session.close();
+  await rm(repo, { recursive: true, force: true });
+});
+
+async function makeFakeValidator(
+  dir: string,
+  name: string,
+  exitCode: 0 | 1,
+  stderr = "",
+): Promise<string> {
+  const file = path.join(dir, name);
+  const stderrLine = stderr
+    ? `process.stderr.write(${JSON.stringify(stderr)});\n`
+    : "";
+  await writeFile(
+    file,
+    `#!/usr/bin/env node\n${stderrLine}process.exit(${exitCode});\n`,
+  );
+  await chmod(file, 0o755);
+  return file;
+}
+
+describe("validate_config", () => {
+  it("returns valid:true with no isError when the validator exits 0", async () => {
+    const validator = await makeFakeValidator(repo, "fake-pass.mjs", 0);
+    session = await startServer(
+      { RENOVATE_CONFIG_VALIDATOR_BIN: validator },
+      { requestTimeoutMs: 30_000 },
+    );
+
+    const res = await session.request<{
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    }>("tools/call", {
+      name: "validate_config",
+      arguments: { configContent: { extends: ["config:recommended"] } },
+    });
+
+    expect(res.result?.isError).toBeFalsy();
+    const payload = JSON.parse(res.result!.content[0]!.text);
+    expect(payload.valid).toBe(true);
+  });
+
+  it("returns valid:false with isError and forwards the validator's stderr when it exits 1", async () => {
+    const validator = await makeFakeValidator(
+      repo,
+      "fake-fail.mjs",
+      1,
+      "ERROR: invalid config option: packageRules[0].matchFoo\n",
+    );
+    session = await startServer(
+      { RENOVATE_CONFIG_VALIDATOR_BIN: validator },
+      { requestTimeoutMs: 30_000 },
+    );
+
+    const res = await session.request<{
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    }>("tools/call", {
+      name: "validate_config",
+      arguments: { configContent: { packageRules: [{ matchFoo: "bar" }] } },
+    });
+
+    expect(res.result?.isError).toBe(true);
+    const payload = JSON.parse(res.result!.content[0]!.text);
+    expect(payload.valid).toBe(false);
+    expect(payload.output).toContain("invalid config option");
+  });
+
+  it("validates a config file on disk via configPath", async () => {
+    const validator = await makeFakeValidator(repo, "fake-pass.mjs", 0);
+    const configPath = path.join(repo, "renovate.json");
+    await writeFile(configPath, JSON.stringify({ extends: ["config:recommended"] }));
+    session = await startServer(
+      { RENOVATE_CONFIG_VALIDATOR_BIN: validator },
+      { requestTimeoutMs: 30_000 },
+    );
+
+    const res = await session.request<{
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    }>("tools/call", {
+      name: "validate_config",
+      arguments: { configPath },
+    });
+
+    expect(res.result?.isError).toBeFalsy();
+    const payload = JSON.parse(res.result!.content[0]!.text);
+    expect(payload.valid).toBe(true);
+  });
+
+  it("returns isError when neither configPath nor configContent is supplied", async () => {
+    session = await startServer({}, { requestTimeoutMs: 30_000 });
+    const res = await session.request<{
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    }>("tools/call", { name: "validate_config", arguments: {} });
+
+    expect(res.result?.isError).toBe(true);
+    expect(res.result!.content[0]!.text).toContain(
+      "Provide either configPath or configContent",
+    );
+  });
+
+  it("wraps spawn failures via formatMissingBinaryError when the validator is not found", async () => {
+    session = await startServer(
+      { RENOVATE_CONFIG_VALIDATOR_BIN: "/nonexistent/path/to/validator" },
+      { requestTimeoutMs: 30_000 },
+    );
+
+    const res = await session.request<{
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    }>("tools/call", {
+      name: "validate_config",
+      arguments: { configContent: { extends: ["config:recommended"] } },
+    });
+
+    expect(res.result?.isError).toBe(true);
+    const text = res.result!.content[0]!.text;
+    expect(text).toContain("renovate-config-validator");
+    expect(text).toContain("check_setup");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds three integration test files under `test/integration/` — `checkSetup.test.ts`, `readConfig.test.ts`, `validateConfig.test.ts` — following the existing `mcpSession` stdio + real-spawn pattern.
- Each tool now has at least one positive and one negative assertion against the real MCP response shape (`content`, `isError`), closing the gap the audit flagged in #59.
- `validate_config` uses fake `#!/usr/bin/env node` validator binaries (pass / fail / missing) pointed at via `RENOVATE_CONFIG_VALIDATOR_BIN`, mirroring the `writeConfig.test.ts` approach so CI still doesn't need Renovate installed.
- `check_setup` stubs both binaries with `/bin/echo` for the happy path and non-existent paths for the MISSING path; `read_config` covers `package.json#renovate`, JSON5, non-object `renovate` field, and priority-order resolution.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` — 203 tests pass (17 files), including the 11 new assertions
- [x] New tests fail if the underlying tool response shape regresses (verified by temporarily flipping `isError` expectations)

Closes #59