### PR TITLE
feat: add get_version tool exposing server version and build mode

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,7 +5,7 @@
       "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        "src/index.ts"
+        "src/lib/version.ts"
       ],
       "changelog-sections": [
         {

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ An MCP server for designing [Renovate](https://github.com/renovatebot/renovate) 
 
 ## What it does
 
-Nine tools plus a preset reference:
+Ten tools plus a preset reference:
 
 | Tool | Purpose |
 | --- | --- |
 | `check_setup` | Report Renovate CLI + validator availability, versions, and install hints. Also runs at startup. |
+| `get_version` | Report the renovate-mcp server version and whether it's a released build (running from `node_modules`) or a local/dev build (typically launched via `command: node` against a checkout). |
 | `read_config` | Locate and parse a repo's Renovate config (`renovate.json`, `renovate.json5`, `.renovaterc*`, `package.json#renovate`, …) in priority order. |
 | `resolve_config` | Expand every `extends` preset offline. Opt in to fetching `github>` / `gitlab>` presets over HTTPS with `externalPresets: true`. |
 | `preview_custom_manager` | Preview a `customManagers` (regex) entry against a local repo — shows file/line hits and extracted dep info. Offline. |

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,10 @@ import { registerPreviewCustomManager } from "./tools/previewCustomManager.js";
 import { registerDryRun } from "./tools/dryRun.js";
 import { registerDryRunDiff } from "./tools/dryRunDiff.js";
 import { registerWriteConfig } from "./tools/writeConfig.js";
+import { registerGetVersion } from "./tools/getVersion.js";
 import { registerPresetResources } from "./resources/presets.js";
 import { checkSetup, startupBanner } from "./lib/setupCheck.js";
+import { SERVER_VERSION } from "./lib/version.js";
 
 const BASE_INSTRUCTIONS = [
   "Design and debug Renovate configurations interactively.",
@@ -40,8 +42,6 @@ const suppressBanner = requireCliRaw === "false" || requireCliRaw === "0";
 const banner = suppressBanner ? null : startupBanner(setup);
 const instructions = banner ? [BASE_INSTRUCTIONS, "", banner].join("\n") : BASE_INSTRUCTIONS;
 
-const SERVER_VERSION = "0.6.0"; // x-release-please-version
-
 const server = new McpServer({ name: "renovate-mcp", version: SERVER_VERSION }, { instructions });
 
 registerCheckSetup(server);
@@ -53,6 +53,7 @@ registerLintConfig(server);
 registerDryRun(server);
 registerDryRunDiff(server);
 registerWriteConfig(server);
+registerGetVersion(server);
 registerPresetResources(server);
 
 const transport = new StdioServerTransport();

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from "node:url";
+
+export const SERVER_VERSION = "0.6.0"; // x-release-please-version
+
+export type BuildMode = "local" | "released";
+
+export interface VersionInfo {
+  version: string;
+  mode: BuildMode;
+  scriptPath: string;
+}
+
+// "released" = the server is running from a `node_modules/` install (global
+// `npm i -g`, project-local `npm i`, or `npx renovate-mcp`). Anything else —
+// most commonly an MCP config of `{"command": "node", "args": [".../dist/index.js"]}`
+// pointed at a checkout — is treated as a local/dev build.
+function detectMode(scriptPath: string): BuildMode {
+  return /[\\/]node_modules[\\/]/.test(scriptPath) ? "released" : "local";
+}
+
+export function getVersionInfo(entryUrl: string = import.meta.url): VersionInfo {
+  const scriptPath = fileURLToPath(entryUrl);
+  return {
+    version: SERVER_VERSION,
+    mode: detectMode(scriptPath),
+    scriptPath,
+  };
+}
+
+export function describeVersion(info: VersionInfo): string {
+  const tag = info.mode === "local" ? " (local/dev build)" : "";
+  return `renovate-mcp ${info.version}${tag}\nRunning from: ${info.scriptPath}`;
+}

--- a/src/tools/getVersion.ts
+++ b/src/tools/getVersion.ts
@@ -1,0 +1,25 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describeVersion, getVersionInfo } from "../lib/version.js";
+
+export function registerGetVersion(server: McpServer): void {
+  server.registerTool(
+    "get_version",
+    {
+      title: "Get renovate-mcp version",
+      description:
+        "Report the renovate-mcp server version and whether it's a released build (running from node_modules) or a local/dev build (typically launched via `command: node` against a checkout). Useful when the user asks which version is wired up.",
+      inputSchema: {},
+    },
+    async () => {
+      const info = getVersionInfo();
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${describeVersion(info)}\n\n${JSON.stringify(info, null, 2)}`,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/test/integration/getVersion.test.ts
+++ b/test/integration/getVersion.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdir, mkdtemp, copyFile, readdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { SERVER_VERSION } from "../../src/lib/version.js";
+import { startServer, type McpSession } from "../helpers/mcpSession.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const DIST_DIR = path.join(REPO_ROOT, "dist");
+
+let session: McpSession;
+let stagingRoot: string | null = null;
+
+afterEach(async () => {
+  if (session) await session.close();
+  if (stagingRoot) {
+    await rm(stagingRoot, { recursive: true, force: true });
+    stagingRoot = null;
+  }
+});
+
+interface VersionPayload {
+  version: string;
+  mode: "local" | "released";
+  scriptPath: string;
+}
+
+function parseVersionResponse(text: string): VersionPayload {
+  const idx = text.lastIndexOf("\n{");
+  if (idx === -1) throw new Error(`no JSON payload in response:\n${text}`);
+  return JSON.parse(text.slice(idx + 1)) as VersionPayload;
+}
+
+async function copyDir(src: string, dest: string): Promise<void> {
+  await mkdir(dest, { recursive: true });
+  for (const entry of await readdir(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) await copyDir(s, d);
+    else if (entry.isFile()) await copyFile(s, d);
+  }
+}
+
+describe("get_version", () => {
+  it("reports the server version and flags the local/dev build when run from a checkout", async () => {
+    session = await startServer();
+    const res = await session.request<{
+      content: Array<{ type: string; text: string }>;
+    }>("tools/call", { name: "get_version", arguments: {} });
+
+    const text = res.result!.content[0]!.text;
+    expect(text).toContain(`renovate-mcp ${SERVER_VERSION}`);
+    expect(text).toContain("(local/dev build)");
+
+    const payload = parseVersionResponse(text);
+    expect(payload.version).toBe(SERVER_VERSION);
+    expect(payload.mode).toBe("local");
+    expect(payload.scriptPath).not.toMatch(/[\\/]node_modules[\\/]/);
+  });
+
+  it("reports a released build when invoked from inside node_modules", async () => {
+    // Stage the built server under a fake `node_modules/renovate-mcp/` inside
+    // the repo so the path-based detection sees the install marker AND Node's
+    // module resolution can still walk up to the real `node_modules/` for
+    // peer-deps like `@modelcontextprotocol/sdk`.
+    stagingRoot = await mkdtemp(path.join(REPO_ROOT, ".tmp-getver-"));
+    const installed = path.join(stagingRoot, "node_modules", "renovate-mcp");
+    await copyDir(DIST_DIR, path.join(installed, "dist"));
+
+    session = await startServer(
+      {},
+      { serverEntry: path.join(installed, "dist", "index.js") },
+    );
+
+    const res = await session.request<{
+      content: Array<{ type: string; text: string }>;
+    }>("tools/call", { name: "get_version", arguments: {} });
+
+    const text = res.result!.content[0]!.text;
+    expect(text).not.toContain("(local/dev build)");
+    const payload = parseVersionResponse(text);
+    expect(payload.mode).toBe("released");
+    expect(payload.scriptPath).toMatch(/[\\/]node_modules[\\/]renovate-mcp[\\/]/);
+  });
+});

--- a/test/integration/mcpServer.test.ts
+++ b/test/integration/mcpServer.test.ts
@@ -11,7 +11,7 @@ afterEach(async () => {
 });
 
 describe("MCP server stdio handshake", () => {
-  it("lists all nine tools with expected names", async () => {
+  it("lists all ten tools with expected names", async () => {
     session = await startServer();
     const res = await session.request<{ tools: Array<{ name: string }> }>("tools/list");
     const names = (res.result?.tools ?? []).map((t) => t.name).sort();
@@ -19,6 +19,7 @@ describe("MCP server stdio handshake", () => {
       "check_setup",
       "dry_run",
       "dry_run_diff",
+      "get_version",
       "lint_config",
       "preview_custom_manager",
       "read_config",

--- a/test/unit/version.test.ts
+++ b/test/unit/version.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { pathToFileURL } from "node:url";
+import {
+  SERVER_VERSION,
+  describeVersion,
+  getVersionInfo,
+} from "../../src/lib/version.js";
+
+describe("getVersionInfo", () => {
+  it("flags a path inside node_modules as released", () => {
+    const url = pathToFileURL(
+      "/Users/someone/proj/node_modules/renovate-mcp/dist/index.js",
+    ).toString();
+    const info = getVersionInfo(url);
+    expect(info.mode).toBe("released");
+    expect(info.version).toBe(SERVER_VERSION);
+    expect(info.scriptPath).toContain("/node_modules/");
+  });
+
+  it("flags a path outside node_modules as local", () => {
+    const url = pathToFileURL(
+      "/Users/someone/git/renovate-mcp/dist/index.js",
+    ).toString();
+    const info = getVersionInfo(url);
+    expect(info.mode).toBe("local");
+  });
+
+  it("flags a global npm install (lib/node_modules) as released", () => {
+    const url = pathToFileURL(
+      "/usr/local/lib/node_modules/renovate-mcp/dist/index.js",
+    ).toString();
+    expect(getVersionInfo(url).mode).toBe("released");
+  });
+});
+
+describe("describeVersion", () => {
+  it("appends the (local/dev build) marker for local mode", () => {
+    const text = describeVersion({
+      version: "1.2.3",
+      mode: "local",
+      scriptPath: "/some/path/dist/index.js",
+    });
+    expect(text).toContain("renovate-mcp 1.2.3");
+    expect(text).toContain("(local/dev build)");
+    expect(text).toContain("/some/path/dist/index.js");
+  });
+
+  it("omits the marker for released mode", () => {
+    const text = describeVersion({
+      version: "1.2.3",
+      mode: "released",
+      scriptPath: "/x/node_modules/renovate-mcp/dist/index.js",
+    });
+    expect(text).toContain("renovate-mcp 1.2.3");
+    expect(text).not.toContain("(local/dev build)");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new `get_version` MCP tool that reports the server version and whether it's a released build (running from `node_modules`) or a local/dev build (typically launched via `command: node` against a checkout).
- Pulls `SERVER_VERSION` into `src/lib/version.ts` (single source of truth, keeps the `x-release-please-version` marker) and updates `.release-please-config.json` accordingly.
- Build-mode detection is path-based: any script path containing a `node_modules/` segment is treated as released; everything else is flagged as local/dev.

This brings the tool count from 8 to 9 — README's "What it does" table is updated to match.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (232 tests pass)
- [x] New unit test (`test/unit/version.test.ts`) covers both modes plus the `describeVersion` formatter.
- [x] New integration test (`test/integration/getVersion.test.ts`) spawns the real server and asserts both modes — local from the repo checkout, released from a staged `node_modules/renovate-mcp/` install.
- [x] Existing `mcpServer.test.ts` tool-listing assertion updated for the new tool.