### PR TITLE
feat(check_setup): surface platform context for dry_run preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Ten tools plus a preset reference:
 
 | Tool | Purpose |
 | --- | --- |
-| `check_setup` | Report Renovate CLI + validator availability, versions, and install hints. Also runs at startup. |
+| `check_setup` | Report Renovate CLI + validator availability, versions, and install hints. Also surfaces a `platformContext` block (`RENOVATE_PLATFORM` / `RENOVATE_ENDPOINT` values, token-presence booleans, the platform `dry_run` would pick when its input is unset, and notes about likely misconfigurations) so callers can verify env before invoking `dry_run`. Token values are never echoed — only presence booleans. Also runs at startup. |
 | `get_version` | Report the renovate-mcp server version and whether it's a released build (running from `node_modules`) or a local/dev build (typically launched via `command: node` against a checkout). |
 | `read_config` | Locate and parse a repo's Renovate config (`renovate.json`, `renovate.json5`, `.renovaterc*`, `package.json#renovate`, …) in priority order. |
 | `resolve_config` | Expand every `extends` preset offline. Opt in to fetching `github>` / `gitlab>` presets over HTTPS with `externalPresets: true`. |

--- a/src/lib/setupCheck.ts
+++ b/src/lib/setupCheck.ts
@@ -10,11 +10,38 @@ export interface BinaryStatus {
   error?: string;
 }
 
+export type DryRunPlatform = "local" | "github" | "gitlab";
+
+const DRY_RUN_PLATFORMS: readonly DryRunPlatform[] = ["local", "github", "gitlab"] as const;
+
+export interface PlatformContext {
+  /** Raw `RENOVATE_PLATFORM` value from the MCP server's env, or null. */
+  renovatePlatform: string | null;
+  /** Raw `RENOVATE_ENDPOINT` value from the MCP server's env, or null. */
+  renovateEndpoint: string | null;
+  /** Presence-only — never echo the value, since these are secrets. */
+  tokensPresent: {
+    RENOVATE_TOKEN: boolean;
+    GITHUB_TOKEN: boolean;
+    GITLAB_TOKEN: boolean;
+  };
+  /**
+   * What `dry_run` would pick for `--platform=` when its `platform` input is
+   * unset. Mirrors the env fallback in `src/tools/dryRun.ts`: only values
+   * inside the dry_run schema enum (`local`/`github`/`gitlab`) are honored,
+   * anything else silently degrades to `local`.
+   */
+  effectiveDryRunPlatform: DryRunPlatform;
+  /** Cross-checks that are mechanical to compute but easy for callers to miss. */
+  notes: string[];
+}
+
 export interface SetupStatus {
   node: string;
   renovate: BinaryStatus;
   renovateConfigValidator: BinaryStatus;
   envOverrides: Record<string, string>;
+  platformContext: PlatformContext;
   ok: boolean;
   hints: string[];
 }
@@ -79,9 +106,80 @@ export async function checkSetup(): Promise<SetupStatus> {
     renovate,
     renovateConfigValidator,
     envOverrides,
+    platformContext: inspectPlatformContext(process.env),
     ok: renovate.found && renovateConfigValidator.found,
     hints,
   };
+}
+
+/**
+ * Reads platform-related env (RENOVATE_PLATFORM/_ENDPOINT/_TOKEN, plus
+ * GITHUB_TOKEN / GITLAB_TOKEN) and reports what the `dry_run` tool would
+ * actually do when its inputs are unset. Tokens are surfaced as presence
+ * booleans only — values are never echoed.
+ *
+ * The `notes` array carries cross-checks mechanical enough to compute here
+ * but easy to miss when staring at a `dry_run` failure: missing token for the
+ * selected platform, an endpoint that looks like a UI URL instead of an API
+ * URL, and an unsupported `RENOVATE_PLATFORM` value (which silently degrades
+ * to `local` because of dry_run's enum whitelist).
+ */
+export function inspectPlatformContext(env: NodeJS.ProcessEnv): PlatformContext {
+  const renovatePlatformRaw = env.RENOVATE_PLATFORM ?? null;
+  const renovateEndpoint = env.RENOVATE_ENDPOINT ?? null;
+  const tokensPresent = {
+    RENOVATE_TOKEN: Boolean(env.RENOVATE_TOKEN),
+    GITHUB_TOKEN: Boolean(env.GITHUB_TOKEN),
+    GITLAB_TOKEN: Boolean(env.GITLAB_TOKEN),
+  };
+
+  const allowedPlatform = DRY_RUN_PLATFORMS.find((p) => p === renovatePlatformRaw);
+  const effectiveDryRunPlatform: DryRunPlatform = allowedPlatform ?? "local";
+
+  const notes: string[] = [];
+
+  if (renovatePlatformRaw && !allowedPlatform) {
+    notes.push(
+      `\`RENOVATE_PLATFORM=${renovatePlatformRaw}\` is outside the \`dry_run\` schema enum (\`local\`/\`github\`/\`gitlab\`). The env fallback ignores it, so \`dry_run\` will silently use \`local\` — pass \`platform\` explicitly when calling \`dry_run\` if you need a different value.`,
+    );
+  }
+
+  if (allowedPlatform === "gitlab" && !tokensPresent.GITLAB_TOKEN && !tokensPresent.RENOVATE_TOKEN) {
+    notes.push(
+      "`RENOVATE_PLATFORM=gitlab` is set but neither `GITLAB_TOKEN` nor `RENOVATE_TOKEN` is present in the MCP server's env — `gitlab>` presets and private-repo lookups will likely fail to authenticate.",
+    );
+  }
+  if (allowedPlatform === "github" && !tokensPresent.GITHUB_TOKEN && !tokensPresent.RENOVATE_TOKEN) {
+    notes.push(
+      "`RENOVATE_PLATFORM=github` is set but neither `GITHUB_TOKEN` nor `RENOVATE_TOKEN` is present in the MCP server's env — `github>` presets and private-repo lookups will likely fail to authenticate.",
+    );
+  }
+
+  if (renovateEndpoint && looksLikeUiUrl(renovateEndpoint)) {
+    notes.push(
+      `\`RENOVATE_ENDPOINT=${renovateEndpoint}\` looks like a UI URL. Renovate expects an API base URL — typically \`/api/v4/\` for GitLab or \`/api/v3/\` for GitHub Enterprise.`,
+    );
+  }
+
+  return {
+    renovatePlatform: renovatePlatformRaw,
+    renovateEndpoint,
+    tokensPresent,
+    effectiveDryRunPlatform,
+    notes,
+  };
+}
+
+/**
+ * Heuristic: a GitLab/GitHub endpoint is meant to be the API base, but users
+ * routinely paste the web UI URL. Trigger the note when the URL is missing
+ * any `/api/` segment. We avoid hard-coding `/api/v4/` vs `/api/v3/` since
+ * Renovate accepts either depending on platform. Applies regardless of the
+ * effective platform — `dry_run` forwards `--endpoint` even in local mode to
+ * redirect `gitlab>` / `github>` preset shortcuts at a self-hosted host.
+ */
+function looksLikeUiUrl(endpoint: string): boolean {
+  return !/\/api\//.test(endpoint);
 }
 
 // Tools that do not depend on the Renovate CLI and are always callable.
@@ -125,6 +223,20 @@ export function describeSetup(status: SetupStatus): string {
   if (overrideKeys.length > 0) {
     lines.push("Env overrides:");
     for (const key of overrideKeys) lines.push(`  ${key}=${status.envOverrides[key]}`);
+  }
+  lines.push("");
+  lines.push("Platform context:");
+  const ctx = status.platformContext;
+  lines.push(`  RENOVATE_PLATFORM: ${ctx.renovatePlatform ?? "(unset)"}`);
+  lines.push(`  RENOVATE_ENDPOINT: ${ctx.renovateEndpoint ?? "(unset)"}`);
+  const tokens = Object.entries(ctx.tokensPresent)
+    .map(([k, v]) => `${k}=${v ? "set" : "unset"}`)
+    .join(", ");
+  lines.push(`  Tokens: ${tokens}`);
+  lines.push(`  Effective dry_run platform (when input unset): ${ctx.effectiveDryRunPlatform}`);
+  if (ctx.notes.length > 0) {
+    lines.push("  Notes:");
+    for (const n of ctx.notes) lines.push(`    - ${n}`);
   }
   if (status.hints.length > 0) {
     lines.push("");

--- a/test/integration/checkSetup.test.ts
+++ b/test/integration/checkSetup.test.ts
@@ -50,6 +50,13 @@ describe("check_setup", () => {
       renovate: { found: boolean };
       renovateConfigValidator: { found: boolean };
       envOverrides: Record<string, string>;
+      platformContext: {
+        renovatePlatform: string | null;
+        renovateEndpoint: string | null;
+        tokensPresent: Record<string, boolean>;
+        effectiveDryRunPlatform: string;
+        notes: string[];
+      };
     };
     expect(status.ok).toBe(true);
     expect(status.renovate.found).toBe(true);
@@ -58,6 +65,16 @@ describe("check_setup", () => {
       RENOVATE_BIN: "/bin/echo",
       RENOVATE_CONFIG_VALIDATOR_BIN: "/bin/echo",
     });
+    expect(status.platformContext).toBeDefined();
+    expect(status.platformContext.tokensPresent).toEqual(
+      expect.objectContaining({
+        RENOVATE_TOKEN: expect.any(Boolean),
+        GITHUB_TOKEN: expect.any(Boolean),
+        GITLAB_TOKEN: expect.any(Boolean),
+      }),
+    );
+    expect(["local", "github", "gitlab"]).toContain(status.platformContext.effectiveDryRunPlatform);
+    expect(text).toContain("Platform context:");
   });
 
   it("returns isError with MISSING markers when both binaries are absent", async () => {

--- a/test/unit/setupCheck.test.ts
+++ b/test/unit/setupCheck.test.ts
@@ -2,16 +2,36 @@ import { describe, it, expect, afterEach } from "vitest";
 import {
   checkSetup,
   describeSetup,
+  inspectPlatformContext,
   startupBanner,
   unavailableTools,
+  type PlatformContext,
   type SetupStatus,
 } from "../../src/lib/setupCheck.js";
 
 const originalEnv = { ...process.env };
 
+const PLATFORM_ENV_KEYS = [
+  "RENOVATE_PLATFORM",
+  "RENOVATE_ENDPOINT",
+  "RENOVATE_TOKEN",
+  "GITHUB_TOKEN",
+  "GITLAB_TOKEN",
+] as const;
+
 afterEach(() => {
   process.env = { ...originalEnv };
 });
+
+function emptyPlatformContext(): PlatformContext {
+  return {
+    renovatePlatform: null,
+    renovateEndpoint: null,
+    tokensPresent: { RENOVATE_TOKEN: false, GITHUB_TOKEN: false, GITLAB_TOKEN: false },
+    effectiveDryRunPlatform: "local",
+    notes: [],
+  };
+}
 
 describe("checkSetup", () => {
   it("reports both binaries missing when they ENOENT", async () => {
@@ -64,6 +84,7 @@ describe("describeSetup", () => {
         version: "43.0.0",
       },
       envOverrides: {},
+      platformContext: emptyPlatformContext(),
       ok: true,
       hints: [],
     });
@@ -84,6 +105,7 @@ function buildStatus(overrides: Partial<SetupStatus> = {}): SetupStatus {
       version: "43.0.0",
     },
     envOverrides: {},
+    platformContext: emptyPlatformContext(),
     ok: true,
     hints: [],
   };
@@ -195,11 +217,119 @@ describe("describeSetup (legacy verbose diagnostic)", () => {
         error: "spawn renovate-config-validator ENOENT",
       },
       envOverrides: { RENOVATE_BIN: "/x" },
+      platformContext: emptyPlatformContext(),
       ok: false,
       hints: ["hint A", "hint B"],
     });
     expect(out).toContain("MISSING");
     expect(out).toContain("hint A");
     expect(out).toContain("RENOVATE_BIN=/x");
+  });
+});
+
+describe("inspectPlatformContext", () => {
+  function clean(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = {};
+    for (const key of PLATFORM_ENV_KEYS) {
+      delete env[key];
+    }
+    return env;
+  }
+
+  it("returns nulls and false presence flags when nothing is set", () => {
+    const ctx = inspectPlatformContext(clean());
+    expect(ctx.renovatePlatform).toBeNull();
+    expect(ctx.renovateEndpoint).toBeNull();
+    expect(ctx.tokensPresent).toEqual({
+      RENOVATE_TOKEN: false,
+      GITHUB_TOKEN: false,
+      GITLAB_TOKEN: false,
+    });
+    expect(ctx.effectiveDryRunPlatform).toBe("local");
+    expect(ctx.notes).toEqual([]);
+  });
+
+  it("reports tokens by presence only, never echoes values", () => {
+    const ctx = inspectPlatformContext({
+      ...clean(),
+      RENOVATE_TOKEN: "shh-secret-1",
+      GITLAB_TOKEN: "shh-secret-2",
+    });
+    expect(ctx.tokensPresent).toEqual({
+      RENOVATE_TOKEN: true,
+      GITHUB_TOKEN: false,
+      GITLAB_TOKEN: true,
+    });
+    const serialized = JSON.stringify(ctx);
+    expect(serialized).not.toContain("shh-secret-1");
+    expect(serialized).not.toContain("shh-secret-2");
+  });
+
+  it("derives effectiveDryRunPlatform from RENOVATE_PLATFORM when whitelisted", () => {
+    const ctx = inspectPlatformContext({ ...clean(), RENOVATE_PLATFORM: "gitlab", GITLAB_TOKEN: "x" });
+    expect(ctx.renovatePlatform).toBe("gitlab");
+    expect(ctx.effectiveDryRunPlatform).toBe("gitlab");
+  });
+
+  it("warns and falls back to local when RENOVATE_PLATFORM is outside the dry_run enum", () => {
+    const ctx = inspectPlatformContext({ ...clean(), RENOVATE_PLATFORM: "bitbucket" });
+    expect(ctx.renovatePlatform).toBe("bitbucket");
+    expect(ctx.effectiveDryRunPlatform).toBe("local");
+    expect(ctx.notes.some((n) => n.includes("outside the `dry_run` schema enum"))).toBe(true);
+  });
+
+  it("warns when platform=gitlab has no GITLAB_TOKEN nor RENOVATE_TOKEN", () => {
+    const ctx = inspectPlatformContext({ ...clean(), RENOVATE_PLATFORM: "gitlab" });
+    expect(ctx.notes.some((n) => n.includes("`RENOVATE_PLATFORM=gitlab`") && n.includes("authenticate"))).toBe(true);
+  });
+
+  it("does NOT warn about missing token when RENOVATE_TOKEN covers the platform", () => {
+    const ctx = inspectPlatformContext({ ...clean(), RENOVATE_PLATFORM: "gitlab", RENOVATE_TOKEN: "x" });
+    expect(ctx.notes.some((n) => n.includes("authenticate"))).toBe(false);
+  });
+
+  it("warns when platform=github has no GITHUB_TOKEN nor RENOVATE_TOKEN", () => {
+    const ctx = inspectPlatformContext({ ...clean(), RENOVATE_PLATFORM: "github" });
+    expect(ctx.notes.some((n) => n.includes("`RENOVATE_PLATFORM=github`") && n.includes("authenticate"))).toBe(true);
+  });
+
+  it("flags an endpoint that looks like a UI URL", () => {
+    const ctx = inspectPlatformContext({
+      ...clean(),
+      RENOVATE_PLATFORM: "gitlab",
+      GITLAB_TOKEN: "x",
+      RENOVATE_ENDPOINT: "https://gitlab.example.com/",
+    });
+    expect(ctx.notes.some((n) => n.includes("looks like a UI URL"))).toBe(true);
+  });
+
+  it("does not flag an API URL endpoint", () => {
+    const ctx = inspectPlatformContext({
+      ...clean(),
+      RENOVATE_PLATFORM: "gitlab",
+      GITLAB_TOKEN: "x",
+      RENOVATE_ENDPOINT: "https://gitlab.example.com/api/v4/",
+    });
+    expect(ctx.notes.some((n) => n.includes("looks like a UI URL"))).toBe(false);
+  });
+});
+
+describe("describeSetup platform context block", () => {
+  it("renders tokens by presence only and surfaces notes", () => {
+    const out = describeSetup(buildStatus({
+      platformContext: {
+        renovatePlatform: "gitlab",
+        renovateEndpoint: "https://gitlab.example.com/",
+        tokensPresent: { RENOVATE_TOKEN: false, GITHUB_TOKEN: false, GITLAB_TOKEN: true },
+        effectiveDryRunPlatform: "gitlab",
+        notes: ["RENOVATE_ENDPOINT looks like a UI URL"],
+      },
+    }));
+    expect(out).toContain("Platform context:");
+    expect(out).toContain("RENOVATE_PLATFORM: gitlab");
+    expect(out).toContain("GITLAB_TOKEN=set");
+    expect(out).toContain("RENOVATE_TOKEN=unset");
+    expect(out).toContain("Effective dry_run platform (when input unset): gitlab");
+    expect(out).toContain("UI URL");
   });
 });


### PR DESCRIPTION
## Summary

- Adds a \`platformContext\` block to the \`check_setup\` output so callers can verify what \`dry_run\` would inherit from the MCP server's env before invoking it.
- Reports raw \`RENOVATE_PLATFORM\` / \`RENOVATE_ENDPOINT\` values, presence booleans for \`RENOVATE_TOKEN\` / \`GITHUB_TOKEN\` / \`GITLAB_TOKEN\` (values never echoed), and \`effectiveDryRunPlatform\` — the value \`dry_run\` would pick when its \`platform\` input is unset (mirrors the env whitelist in \`src/tools/dryRun.ts\`).
- Computes \`notes\` for the three classes of misconfiguration the issue called out: missing token for the selected platform, an endpoint that looks like a UI URL instead of an API URL, and a \`RENOVATE_PLATFORM\` value outside the dry_run schema enum that silently degrades to \`local\`.
- Extends the human-readable \`describeSetup\` rendering with the same context block.

Closes #107.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm test\` (270 / 270 passing)
- [x] New unit tests for \`inspectPlatformContext\` covering: empty env, presence-only token reporting (asserts secret values are not present in the serialized output), env-derived \`effectiveDryRunPlatform\`, unsupported platform fallback to \`local\`, missing-token notes for both gitlab and github, \`RENOVATE_TOKEN\` covering either platform, UI-URL endpoint detection.
- [x] Updated existing fixtures and the \`check_setup\` integration test to assert the new field is surfaced end-to-end over stdio.