### PR TITLE
fix(prepack): guard against missing shebang before chmod

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:coverage": "vitest run --coverage",
     "generate:presets": "node scripts/generate-presets.mjs",
     "generate:managers": "node scripts/generate-managers.mjs",
-    "prepack": "npm run build && chmod +x dist/index.js"
+    "prepack": "npm run build && node -e \"if (!require('fs').readFileSync('dist/index.js','utf8').startsWith('#!')) { console.error('dist/index.js missing shebang'); process.exit(1); }\" && chmod +x dist/index.js"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary
- prepack now verifies `dist/index.js` starts with `#!` before running `chmod +x`, so a future refactor that drops the shebang from `src/index.ts` fails the publish loudly instead of shipping a broken `bin` entry that crashes on first run.

Closes #76.

## Test plan
- [x] `npm pack --dry-run` succeeds with the shebang present in `src/index.ts`
- [x] Removing the shebang from `src/index.ts` makes `npm pack --dry-run` fail with `dist/index.js missing shebang` (exit 1)