### PR TITLE
chore(renovate): dogfood customManagers and packageRules in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Real Renovate config for renovate-mcp, also kept as a showcase. Edit with this repo's preview_custom_manager (iterate on regex managers) and lint_config (catch Renovate-specific footguns), then dry_run before committing.",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Keep the Renovate version snapshot embedded in the generated preset catalogue in lockstep with the renovate devDependency. Re-run `npm run generate:presets` after the package.json bump merges so the file is fully refreshed.",
+      "fileMatch": ["^src/data/presets\\.generated\\.ts$"],
+      "matchStrings": [
+        "RENOVATE_VERSION = \"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "renovate",
+      "datasourceTemplate": "npm"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Group all devDependency updates into a single PR to minimise tooling churn.",
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "dev dependencies"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Promotes the repo's bare `config:recommended` `renovate.json` into a working showcase that exercises the project's own tooling:

- **Regex customManager** that pulls `RENOVATE_VERSION` out of `src/data/presets.generated.ts` and feeds it into the `npm` datasource (depName `renovate`). Picks up the same Renovate version that drives the committed preset catalogue, so when the `renovate` devDependency bumps, this surfaces a reminder to re-run `npm run generate:presets`.
- **packageRule** that groups all `devDependencies` updates into a single PR to minimise tooling churn.
- **`description` fields** at the root, customManager, and packageRule levels pointing future readers at this repo's `preview_custom_manager` and `lint_config` tools as the recommended editing loop.

`fileMatch` is intentionally retained over the migrated `managerFilePatterns` form so this repo's own `preview_custom_manager` (which still expects the older field name) can dogfood the showcase end-to-end. Renovate's validator emits a `Config migration` info note for that, but `valid: true` and `lint_config` clean.

Closes #73.

## Test plan

- [x] `mcp__renovate__lint_config` against the new `renovate.json` returns `clean: true`, zero findings
- [x] `mcp__renovate__preview_custom_manager` against the customManager block returns 1 hit on `src/data/presets.generated.ts:10`, extracting `renovate@43.139.5` via the `npm` datasource
- [x] `mcp__renovate__validate_config` returns `valid: true` (with the expected Renovate config-migration info note about `fileMatch` → `managerFilePatterns`)