### PR TITLE
test(tmp-dirs): include test filename and pid in mkdtemp prefixes

### DIFF
--- a/test/integration/dryRun.test.ts
+++ b/test/integration/dryRun.test.ts
@@ -15,7 +15,9 @@ let repo: string;
 let session: McpSession;
 
 beforeEach(async () => {
-  repo = await mkdtemp(path.join(tmpdir(), "rmcp-dry-"));
+  repo = await mkdtemp(
+    path.join(tmpdir(), `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-`),
+  );
 });
 
 afterEach(async () => {

--- a/test/integration/mcpServer.test.ts
+++ b/test/integration/mcpServer.test.ts
@@ -67,7 +67,12 @@ describe("startup instructions banner", () => {
 describe("read_config end-to-end", () => {
   let repo: string;
   beforeEach(async () => {
-    repo = await mkdtemp(path.join(tmpdir(), "rmcp-e2e-"));
+    repo = await mkdtemp(
+      path.join(
+        tmpdir(),
+        `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-e2e-`,
+      ),
+    );
   });
   afterEach(async () => {
     await rm(repo, { recursive: true, force: true });
@@ -104,7 +109,12 @@ describe("read_config end-to-end", () => {
 describe("preview_custom_manager end-to-end", () => {
   let repo: string;
   beforeEach(async () => {
-    repo = await mkdtemp(path.join(tmpdir(), "rmcp-pcm-"));
+    repo = await mkdtemp(
+      path.join(
+        tmpdir(),
+        `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-pcm-`,
+      ),
+    );
   });
   afterEach(async () => {
     await rm(repo, { recursive: true, force: true });
@@ -161,7 +171,12 @@ describe("preview_custom_manager end-to-end", () => {
 describe("lint_config end-to-end", () => {
   let repo: string;
   beforeEach(async () => {
-    repo = await mkdtemp(path.join(tmpdir(), "rmcp-lint-"));
+    repo = await mkdtemp(
+      path.join(
+        tmpdir(),
+        `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-lint-`,
+      ),
+    );
   });
   afterEach(async () => {
     await rm(repo, { recursive: true, force: true });

--- a/test/integration/readConfig.test.ts
+++ b/test/integration/readConfig.test.ts
@@ -27,7 +27,9 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  repo = await mkdtemp(path.join(tmpdir(), "rmcp-read-"));
+  repo = await mkdtemp(
+    path.join(tmpdir(), `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-`),
+  );
 });
 
 afterEach(async () => {

--- a/test/integration/validateConfig.test.ts
+++ b/test/integration/validateConfig.test.ts
@@ -15,7 +15,9 @@ let repo: string;
 let session: McpSession;
 
 beforeEach(async () => {
-  repo = await mkdtemp(path.join(tmpdir(), "rmcp-validate-"));
+  repo = await mkdtemp(
+    path.join(tmpdir(), `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-`),
+  );
 });
 
 afterEach(async () => {

--- a/test/integration/writeConfig.test.ts
+++ b/test/integration/writeConfig.test.ts
@@ -24,7 +24,9 @@ let repo: string;
 let session: McpSession;
 
 beforeEach(async () => {
-  repo = await mkdtemp(path.join(tmpdir(), "rmcp-write-"));
+  repo = await mkdtemp(
+    path.join(tmpdir(), `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-`),
+  );
 });
 
 afterEach(async () => {
@@ -99,7 +101,12 @@ describe("write_config", () => {
   it("rejects a filename whose resolved parent escapes repoPath via a symlink", async () => {
     session = await startServer();
 
-    const outside = await mkdtemp(path.join(tmpdir(), "rmcp-outside-"));
+    const outside = await mkdtemp(
+      path.join(
+        tmpdir(),
+        `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-outside-`,
+      ),
+    );
     try {
       await symlink(outside, path.join(repo, "escape"));
 

--- a/test/unit/configLocations.test.ts
+++ b/test/unit/configLocations.test.ts
@@ -7,7 +7,9 @@ import { locateConfig } from "../../src/lib/configLocations.js";
 let repo: string;
 
 beforeEach(async () => {
-  repo = await mkdtemp(path.join(tmpdir(), "rmcp-test-"));
+  repo = await mkdtemp(
+    path.join(tmpdir(), `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-`),
+  );
 });
 
 afterEach(async () => {

--- a/test/unit/customManagerPreview.test.ts
+++ b/test/unit/customManagerPreview.test.ts
@@ -7,7 +7,9 @@ import { previewCustomManager } from "../../src/lib/customManagerPreview.js";
 let repo: string;
 
 beforeEach(async () => {
-  repo = await mkdtemp(path.join(tmpdir(), "rmcp-cmp-"));
+  repo = await mkdtemp(
+    path.join(tmpdir(), `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-`),
+  );
 });
 
 afterEach(async () => {

--- a/test/unit/mcpSession.test.ts
+++ b/test/unit/mcpSession.test.ts
@@ -24,7 +24,9 @@ afterEach(async () => {
 });
 
 async function writeFakeServer(body: string): Promise<string> {
-  workDir = await mkdtemp(path.join(tmpdir(), "rmcp-fakesrv-"));
+  workDir = await mkdtemp(
+    path.join(tmpdir(), `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-`),
+  );
   const file = path.join(workDir, "server.mjs");
   await writeFile(file, `#!/usr/bin/env node\n${body}\n`);
   await chmod(file, 0o755);

--- a/test/unit/renovateCli.test.ts
+++ b/test/unit/renovateCli.test.ts
@@ -44,7 +44,9 @@ describe("run() streaming observers", () => {
   let dir: string;
 
   beforeEach(async () => {
-    dir = await mkdtemp(path.join(tmpdir(), "rmcp-run-"));
+    dir = await mkdtemp(
+      path.join(tmpdir(), `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-`),
+    );
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary
- Replaces shared shorthand prefixes (`rmcp-dry-`, `rmcp-write-`, `rmcp-e2e-`, …) with `rmcp-${basename}-${pid}-` across 9 test files.
- Purely cosmetic: `mkdtemp` already guarantees uniqueness, but the new prefix makes `ls /tmp/rmcp-*` self-documenting when tests abort mid-run.
- Files with multiple distinct `mkdtemp` call sites keep a trailing discriminator (`-outside-`, `-e2e-`, `-pcm-`, `-lint-`).

Closes #69.

## Test plan
- [x] `npm run typecheck`
- [x] All 8 modified test files pass when run together (`vitest run` on the touched files: 79/79 green).
- [x] Spot-checked: an aborted test now leaves `/tmp/rmcp-dryRun.test-12345-…` instead of `/tmp/rmcp-dry-…`.