### PR TITLE
test(configLocations): table-driven coverage of full priority chain

### DIFF
--- a/test/unit/configLocations.test.ts
+++ b/test/unit/configLocations.test.ts
@@ -69,27 +69,58 @@ describe("locateConfig", () => {
     expect(await locateConfig(repo)).toBeNull();
   });
 
-  it("prefers renovate.json over .renovaterc", async () => {
-    await writeFile(path.join(repo, "renovate.json"), '{"schedule":["weekly"]}');
-    await writeFile(path.join(repo, ".renovaterc"), '{"schedule":["daily"]}');
-    const loc = await locateConfig(repo);
-    expect(loc?.relPath).toBe("renovate.json");
-    expect(loc?.config).toMatchObject({ schedule: ["weekly"] });
-  });
+  // Mirrors the priority order in src/lib/configLocations.ts. Each adjacent
+  // pair is tested below to catch reorderings within the chain.
+  const PRIORITY_CHAIN = [
+    "renovate.json",
+    "renovate.json5",
+    ".github/renovate.json",
+    ".github/renovate.json5",
+    ".gitlab/renovate.json",
+    ".gitlab/renovate.json5",
+    ".renovaterc",
+    ".renovaterc.json",
+    ".renovaterc.json5",
+    "package.json",
+  ] as const;
 
-  it("prefers renovate.json over package.json#renovate", async () => {
-    await writeFile(path.join(repo, "renovate.json"), '{"schedule":["weekly"]}');
-    await writeFile(
-      path.join(repo, "package.json"),
-      JSON.stringify({
-        name: "x",
-        version: "0.0.1",
-        renovate: { schedule: ["daily"] },
-      }),
-    );
-    const loc = await locateConfig(repo);
-    expect(loc?.relPath).toBe("renovate.json");
-  });
+  async function writeConfigAt(relPath: string, marker: string): Promise<void> {
+    const dir = path.dirname(relPath);
+    if (dir !== ".") await mkdir(path.join(repo, dir), { recursive: true });
+    if (relPath === "package.json") {
+      await writeFile(
+        path.join(repo, relPath),
+        JSON.stringify({
+          name: "x",
+          version: "0.0.1",
+          renovate: { schedule: [marker] },
+        }),
+      );
+      return;
+    }
+    if (relPath.endsWith(".json5")) {
+      await writeFile(
+        path.join(repo, relPath),
+        `{\n  // marker\n  schedule: ["${marker}"],\n}`,
+      );
+      return;
+    }
+    await writeFile(path.join(repo, relPath), `{"schedule":["${marker}"]}`);
+  }
+
+  const ADJACENT_PAIRS = PRIORITY_CHAIN.slice(0, -1).map(
+    (higher, i) => [higher, PRIORITY_CHAIN[i + 1]!] as const,
+  );
+
+  for (const [higher, lower] of ADJACENT_PAIRS) {
+    it(`prefers ${higher} over ${lower}`, async () => {
+      await writeConfigAt(higher, "higher");
+      await writeConfigAt(lower, "lower");
+      const loc = await locateConfig(repo);
+      expect(loc?.relPath).toBe(higher);
+      expect(loc?.config).toMatchObject({ schedule: ["higher"] });
+    });
+  }
 
   it("throws on malformed JSON", async () => {
     await writeFile(path.join(repo, "renovate.json"), "{not json");


### PR DESCRIPTION
## Summary
- Replaces the two ad-hoc pairwise priority tests in `test/unit/configLocations.test.ts` with a single table-driven generator that emits one `it` block per adjacent `(higher, lower)` pair in the official priority chain (9 boundaries: `renovate.json` → `renovate.json5` → `.github/renovate.json` → `.github/renovate.json5` → `.gitlab/renovate.json` → `.gitlab/renovate.json5` → `.renovaterc` → `.renovaterc.json` → `.renovaterc.json5` → `package.json#renovate`).
- The chain is declared inline in the test file as the expected ordering — if anyone reorders `CANDIDATES` in `src/lib/configLocations.ts` or shifts the `package.json` fallback, exactly the affected boundary test fails with a self-describing name (e.g. `prefers .renovaterc over .renovaterc.json`).

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npx vitest run test/unit/configLocations.test.ts` — all 16 cases (7 original + 9 generated boundary cases) pass.
- [x] Verification per the issue: temporarily swapped `.renovaterc` and `.renovaterc.json` in the priority array; only the `prefers .renovaterc over .renovaterc.json` case failed, with a clear message. Reverted.

Closes #68