### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -32,7 +32,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage
           path: coverage/

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,13 +29,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
       contents: read
       id-token: write  # required for npm provenance via OIDC
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .release-please-config.json

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Real Renovate config for renovate-mcp, also kept as a showcase. Edit with this repo's preview_custom_manager (iterate on regex managers) and lint_config (catch Renovate-specific footguns), then dry_run before committing.",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "customManagers": [
     {


### PR DESCRIPTION
## Summary

- Pin every `uses:` in `.github/workflows/` to a 40-char commit SHA with a `# vX.Y.Z` trailing comment so reviewers can see what's pinned.
- Add `helpers:pinGitHubActionDigests` to `renovate.json` so Renovate keeps the SHAs (and their comments) in sync via PRs.

## Why

`publish.yml` holds `id-token: write` for npm Trusted Publishers / OIDC. A retag of any action used in that workflow could mint a malicious release with provenance. Major-version tags are mutable; commit SHAs are not. `config:recommended` stays in place for everything else; `helpers:pinGitHubActionDigests` is the narrow preset for Action digest pinning only.

## Pinned actions

| Action | SHA | Version |
| --- | --- | --- |
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `actions/setup-node` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | v6.4.0 |
| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7.0.1 |
| `googleapis/release-please-action` | `45996ed1f6d02564a971a2fa1b5860e934307cf7` | v5.0.0 |
| `anthropics/claude-code-action` | `567fe954a4527e81f132d87d1bdbcc94f7737434` | v1.0.107 |

## Test plan

- [ ] CI passes on this PR (workflows still parse and resolve to runnable Actions)
- [ ] After merge, Renovate opens a follow-up PR bumping at least one of the pinned SHAs (acceptance criterion from #123)
- [ ] `renovate-config-validator` accepts the new `renovate.json` (already verified locally via the repo's own `validate_config` tool)

Closes #123