### PR TITLE
feat: declare Windows unsupported via package.json os field

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ See [Design notes](#design-notes) for implementation details (timeouts, safety c
 
 **Required**
 
+- Linux or macOS. Windows is not supported — `package.json` declares `"os": ["darwin", "linux"]`, so `npm i` surfaces an `EBADPLATFORM` warning on Windows, and the server exits with a clear stderr message at startup. Run on WSL2 or a Linux/macOS host instead.
 - Node.js ≥ 24 (aligns with Renovate's own engine requirement).
 - Renovate on your `PATH` — either a global install (`npm i -g renovate`) or a project-local install that exposes `renovate` + `renovate-config-validator` via `npm exec`. Only needed for `validate_config`, `dry_run`, and `write_config`; the offline tools (`read_config`, `resolve_config`, `preview_custom_manager`, `lint_config`) work without it.
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
   "engines": {
     "node": ">=24"
   },
+  "os": [
+    "darwin",
+    "linux"
+  ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ignore": "^7.0.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,13 @@ const BASE_INSTRUCTIONS = [
   "Built-in preset reference: renovate://presets (namespace index), renovate://presets/{namespace} (one namespace), renovate://preset/{name} (one preset's expanded JSON).",
 ].join("\n");
 
+if (process.platform === "win32") {
+  process.stderr.write(
+    "renovate-mcp does not support Windows. Supported platforms are Linux and macOS — see the `os` field in package.json. Run on WSL2 or a Linux/macOS host instead.\n",
+  );
+  process.exit(1);
+}
+
 const setup = await checkSetup();
 
 // `RENOVATE_MCP_REQUIRE_CLI=false` is the opt-out for users who have


### PR DESCRIPTION
## Summary

Closes #121.

- Adds `"os": ["darwin", "linux"]` to `package.json` so `npm i` surfaces an `EBADPLATFORM` warning (or refuses, depending on npm config) on Windows instead of installing silently.
- Adds a fail-fast guard in `src/index.ts` (before `checkSetup()`) that writes a clear unsupported-platform message to stderr and exits 1 when `process.platform === "win32"`. Users now see an explicit signal pointing at the `os` field rather than the misleading "binary not found" error from `spawn()` calls in `renovateCli.ts`.
- Documents the supported platforms (Linux, macOS) in the README "Requirements" section.

No code added that pretends to fix Windows compatibility — Windows remains intentionally out of scope.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (304/304)
- [ ] Verified by maintainer that `npm i` on Windows surfaces `EBADPLATFORM` (cannot exercise locally on macOS)
- [ ] Verified by maintainer that running `dist/index.js` on Windows prints the stderr message and exits non-zero