### PR TITLE
ci: add macos-latest to CI OS matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@ on:
 
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -31,7 +35,7 @@ jobs:
       - run: npm run test:coverage
 
       - name: Upload coverage report
-        if: always()
+        if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ npm run generate:managers # regenerate src/data/managers.generated.ts from the r
 
 The preset catalogue at `src/data/presets.generated.ts` and the manager-name list at `src/data/managers.generated.ts` are committed snapshots of Renovate's built-in presets and manager registry. Runtime code never imports the `renovate` package — only the `scripts/generate-*.mjs` scripts do. Regenerate both after bumping the `renovate` devDependency.
 
-CI runs `typecheck`, `build`, and `test:coverage` on Node 24 for every PR and push to `main` (see `.github/workflows/ci.yml`). Coverage is uploaded as a per-run artifact; no threshold is enforced yet.
+CI runs `typecheck`, `build`, and `test:coverage` on Node 24 for every PR and push to `main` (see `.github/workflows/ci.yml`), across an OS matrix of `ubuntu-latest` and `macos-latest` with `fail-fast: false` so a platform-specific regression on either side surfaces. Coverage is uploaded as a per-run artifact from the Ubuntu job only (to avoid name collisions); no threshold is enforced yet.
 
 `.github/workflows/claude.yml` is maintainer tooling: it lets the repo owner trigger [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) by mentioning `@claude` in an issue, issue comment, PR review, or PR review comment. It's gated on `sender.login == repository_owner`, so mentions from anyone else are ignored. The workflow needs the `CLAUDE_CODE_OAUTH_TOKEN` secret on the repo; outside contributors and forks do not need any Anthropic credentials to work on this project.
 


### PR DESCRIPTION
## Summary
- Add a matrix of `ubuntu-latest` and `macos-latest` to the `build-test` job (`fail-fast: false`) so BSD-vs-GNU divergences (`fs.realpath` ancestor walk in `writeConfig`, default `os.tmpdir()` layout used by `dryRun` and unit tests, `SIGKILL` timing in `renovateCli`, case-insensitive filesystem behavior in `customManagerPreview`) surface in CI rather than only on contributor laptops.
- Gate the coverage upload to the Ubuntu job (`always() && matrix.os == 'ubuntu-latest'`) to avoid artifact-name collisions across the matrix.
- Update README's CI section to reflect the new matrix and the single-job coverage upload.

Closes #122.

## Test plan
- [ ] Workflow run on this PR shows two `build-test` jobs (`build-test (ubuntu-latest)` and `build-test (macos-latest)`) and both go green.
- [ ] Only one `coverage` artifact is produced per workflow run (from the Ubuntu job).