### PR TITLE
ci: add dependency-review-action on pull_request

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,17 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high

--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ The preset catalogue at `src/data/presets.generated.ts` and the manager-name lis
 
 CI runs `typecheck`, `build`, and `test:coverage` on Node 24 for every PR and push to `main` (see `.github/workflows/ci.yml`), across an OS matrix of `ubuntu-latest` and `macos-latest` with `fail-fast: false` so a platform-specific regression on either side surfaces. Coverage is uploaded as a per-run artifact from the Ubuntu job only (to avoid name collisions); no threshold is enforced yet.
 
+`.github/workflows/dependency-review.yml` runs [`actions/dependency-review-action`](https://github.com/actions/dependency-review-action) on every PR and fails the check when a newly introduced dependency carries a CVE of `high` severity or above. Findings also render inline in the PR's "Files changed" / Conversation tabs.
+
 `.github/workflows/claude.yml` is maintainer tooling: it lets the repo owner trigger [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) by mentioning `@claude` in an issue, issue comment, PR review, or PR review comment. It's gated on `sender.login == repository_owner`, so mentions from anyone else are ignored. The workflow needs the `CLAUDE_CODE_OAUTH_TOKEN` secret on the repo; outside contributors and forks do not need any Anthropic credentials to work on this project.
 
 ## Release flow


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/dependency-review.yml` running [`actions/dependency-review-action`](https://github.com/actions/dependency-review-action) on every PR.
- Fails the check when a newly introduced dependency carries a CVE of `high` severity or above (sensible default per the issue, doesn't block routine bumps).
- Action is SHA-pinned (`v4.9.0` → `2031cfc0…`) consistent with #123.
- Updates `README.md` Development section to describe the new workflow.

Closes #125.

## Test plan

- [ ] CI workflow appears on this PR and runs to completion.
- [ ] Findings render in the PR's "Files changed" / Conversation tabs (no high-severity CVEs expected — should pass).