### PR TITLE
docs: add issue forms and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,80 @@
+name: Bug
+description: Something isn't working
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing! Please fill in as much as you can — reproduction steps and version info are the most important.
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Suggested priority
+      description: Best guess — the maintainer will re-triage. Picking helps frame the bug, not lock it.
+      options:
+        - "priority:low (polish/nit)"
+        - "priority:medium (narrow blast radius)"
+        - "priority:high (correctness/security/hang)"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences on what's wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Minimal steps, config, or input that triggers the bug. Include the tool call(s) if relevant.
+      placeholder: |
+        1. Configure renovate-mcp with ...
+        2. Call tool `preview_custom_manager` with ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include error output / stack traces verbatim if any.
+    validations:
+      required: true
+  - type: input
+    id: node-version
+    attributes:
+      label: Node version
+      description: Output of `node --version` (must be ≥ 24).
+      placeholder: v24.0.0
+    validations:
+      required: true
+  - type: input
+    id: renovate-version
+    attributes:
+      label: Renovate CLI version
+      description: Output of `renovate --version`, or "not installed" if the bug doesn't involve the CLI.
+      placeholder: "41.0.0"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: macOS 15.0 / Ubuntu 24.04 / ...
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Logs, screenshots, related issues, hypotheses.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,54 @@
+name: Feature / enhancement
+description: Propose new behavior or an enhancement to an existing tool
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The repo's tool surface is intentionally small. Before filing, please skim `README.md` and `CLAUDE.md` to confirm this isn't already in scope or deliberately out of scope.
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Suggested priority
+      description: Best guess — the maintainer will re-triage.
+      options:
+        - "priority:low (nice to have)"
+        - "priority:medium (clear user value)"
+        - "priority:high (blocks a real workflow)"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences on what you want to add or change.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve? What workflow does it unblock?
+    validations:
+      required: true
+  - type: textarea
+    id: sketch
+    attributes:
+      label: Sketch
+      description: Rough proposal — input shape, output shape, where it would live in the codebase. Code snippets welcome.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you tried, or other designs you weighed and rejected.
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this is done? Bullet list preferred.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!-- Thanks for the PR! Fill in the sections below; delete what doesn't apply. -->
+
+## What changed
+
+<!-- One or two sentences on the user-visible change. Link the issue this closes (e.g. "Closes #123"). -->
+
+## Why
+
+<!-- The motivation, if not obvious from the linked issue. -->
+
+## README sync (per CLAUDE.md)
+
+`CLAUDE.md` requires `README.md` to track the user-facing surface. Tick the relevant boxes:
+
+- [ ] Tool table updated (a tool was added, removed, or renamed)
+- [ ] Tool row updated (inputs or externally-visible behavior changed)
+- [ ] "Requirements" updated (env vars or installed binaries changed)
+- [ ] "Example prompts" / "Example session" re-read for tool-name or shape drift
+- [ ] N/A — change doesn't touch any of the above
+
+## Test plan
+
+<!-- How did you verify? `npm test`, manual MCP session, dry_run output, etc. -->


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/bug.yml` and `.github/ISSUE_TEMPLATE/feature.yml` so external filers pick a priority/type up-front, locking in the maintainer's existing `bug`/`enhancement` × `priority:{low,medium,high}` triage taxonomy.
- Adds `.github/pull_request_template.md` pre-filled with the README-keep-in-sync checklist already documented in `CLAUDE.md`, so the most common review nit gets caught at PR-author time.
- CODEOWNERS deliberately skipped — single-maintainer repo, low value right now (per issue triage).

Closes #127.

## Test plan

- [ ] On GitHub: filing a new issue offers the bug/feature template chooser.
- [ ] On GitHub: opening a new PR pre-fills the body with the README-sync checklist.
- [ ] YAML files parse cleanly (validated locally with `js-yaml`).