### PR TITLE
ci: smoke-test the published tarball before npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,4 +27,12 @@ jobs:
       - run: npm run build
       - run: npm test
 
+      # Smoke-test the would-be-published tarball: pack it, install globally,
+      # and verify the resulting `renovate-mcp` binary answers an MCP
+      # `initialize` request. Catches `files`/`bin`/shebang/startup regressions
+      # that the in-tree tests miss because they read from the working tree.
+      - run: npm pack
+      - run: npm install -g ./renovate-mcp-*.tgz
+      - run: node scripts/smoke-test-tarball.mjs
+
       - run: npm publish

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Releases are automated via [release-please](https://github.com/googleapis/releas
 1. Merge Conventional Commits to `main` (`feat:`, `fix:`, etc.)
 2. release-please opens or updates a release PR that bumps the version and updates `CHANGELOG.md`
 3. Merging the release PR creates a GitHub release and tag
-4. The `publish` workflow (`.github/workflows/publish.yml`) fires on the release event, runs the test suite, and runs `npm publish` with provenance
+4. The `publish` workflow (`.github/workflows/publish.yml`) fires on the release event, runs the test suite, smoke-tests the packed tarball end-to-end (install globally, then run an MCP `initialize` handshake against the resulting `renovate-mcp` binary), and only then runs `npm publish` with provenance
 
 Publishing uses [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers) — no npm token is stored in the repo. Instead the workflow authenticates to npm via OIDC using the `id-token: write` permission. Trusted Publishers must be configured on the npm package settings page before OIDC publishes will succeed; this requires the package to already exist, so the **first release must be published manually once** (`npm login && npm publish` from a clean build), after which Trusted Publishers can be wired up and all subsequent releases go through this workflow.
 

--- a/scripts/smoke-test-tarball.mjs
+++ b/scripts/smoke-test-tarball.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Spawn the installed `renovate-mcp` binary and verify it completes an MCP
+// `initialize` handshake. Used by publish.yml to gate `npm publish` on the
+// would-be-published tarball actually starting up — catches regressions in the
+// `bin` shim, the `files` allowlist, the shebang, and runtime startup that the
+// in-tree test suite can't see because it reads from the working tree.
+
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const EXPECTED_SERVER_NAME = "renovate-mcp";
+const BIN = process.env.RENOVATE_MCP_BIN ?? "renovate-mcp";
+
+const child = spawn(BIN, { stdio: ["pipe", "pipe", "pipe"] });
+
+let stderr = "";
+child.stderr.setEncoding("utf8");
+child.stderr.on("data", (chunk) => {
+  stderr += chunk;
+});
+
+function fail(msg) {
+  console.error(`smoke test failed: ${msg}`);
+  if (stderr) console.error(`--- server stderr ---\n${stderr.trimEnd()}`);
+  child.kill("SIGKILL");
+  process.exit(1);
+}
+
+child.on("error", (err) => fail(`spawn ${BIN}: ${err.message}`));
+
+const timeout = setTimeout(
+  () => fail(`no initialize response after ${REQUEST_TIMEOUT_MS}ms`),
+  REQUEST_TIMEOUT_MS,
+);
+
+const rl = createInterface({ input: child.stdout });
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (msg.id !== 1 || !msg.result) return;
+  clearTimeout(timeout);
+  const serverName = msg.result?.serverInfo?.name;
+  if (serverName !== EXPECTED_SERVER_NAME) {
+    fail(`unexpected serverInfo.name: ${JSON.stringify(serverName)}`);
+  }
+  console.log(`smoke test passed: ${serverName} responded to initialize`);
+  child.stdin.end();
+  child.kill();
+  process.exit(0);
+});
+
+const initRequest = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "smoke", version: "0" },
+  },
+};
+child.stdin.write(JSON.stringify(initRequest) + "\n");


### PR DESCRIPTION
## Summary

- Adds a tarball smoke test step to `publish.yml` between `npm test` and `npm publish` — packs the artifact, installs it globally, and verifies the resulting `renovate-mcp` binary completes an MCP `initialize` handshake.
- New standalone script `scripts/smoke-test-tarball.mjs` (no test-helper coupling) keeps the workflow YAML clean and is reusable for local verification via `RENOVATE_MCP_BIN=… node scripts/smoke-test-tarball.mjs`.
- Updates the README "Release flow" step 4 to describe the new gate.

Catches regressions the in-tree suite cannot see because it reads from the working tree, not from the published artifact: `files` allowlist drift, broken `bin` shim, missing/garbled shebang, runtime startup failures only visible through the global bin shim.

Closes #124.

## Test plan

- [x] Verified locally: `npm pack` + `npm install ./renovate-mcp-0.8.0.tgz` into a clean tmp dir, then `RENOVATE_MCP_BIN=…/.bin/renovate-mcp node scripts/smoke-test-tarball.mjs` → `smoke test passed: renovate-mcp responded to initialize`.
- [x] Verified failure paths: spawn-failure exits 1 with stderr; non-responsive child exits 1 after the 10s timeout.
- [x] `npm run typecheck` clean.
- [ ] CI on the next release will exercise this in the actual `publish.yml` flow (cannot be tested in PR CI since `publish.yml` only fires on `release: published`).