### PR TITLE
chore: sync os field from package.json to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "renovate-mcp",
       "version": "0.8.0",
       "license": "MIT",
+      "os": [
+        "darwin",
+        "linux"
+      ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ignore": "^7.0.5",


### PR DESCRIPTION
## Summary

- Re-runs \`npm install --package-lock-only\` so the \`packages[\"\"]\` entry in \`package-lock.json\` reflects the \`os: [darwin, linux]\` field that landed in package.json via 56b4f7e.
- No dependency tree changes — the diff is exactly the four-line \`os\` array on the root entry.

## Why this drifted

\`56b4f7e\` added \`os\` to \`package.json\` without re-running \`npm install\`, so the lock-file's frozen snapshot of root metadata stayed stale. \`npm ci\` (used in CI) only validates the dependency tree, not arbitrary root metadata fields like \`os\`/\`engines\`/\`bin\`, so nothing flagged it.

## Test plan

- [x] \`npm install --package-lock-only\` produces no further diff after this commit.
- [x] \`npm ci\` still passes (no dependency changes).

## Follow-up

A separate task is to add a CI guard that catches this kind of drift (e.g. a job that runs \`npm install --package-lock-only\` and fails on a non-empty \`git diff\`) — happy to open an issue if useful.