### PR TITLE
feat: register stderr-only unhandledRejection / uncaughtException handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,17 @@ import { registerGetVersion } from "./tools/getVersion.js";
 import { registerPresetResources } from "./resources/presets.js";
 import { checkSetup, startupBanner } from "./lib/setupCheck.js";
 import { SERVER_VERSION } from "./lib/version.js";
+import { logError } from "./lib/log.js";
+
+// Register before any work: stdout carries JSON-RPC frames, so a stray Node-default
+// log of an unhandled rejection / uncaught exception would corrupt MCP framing.
+process.on("unhandledRejection", (reason) => {
+  logError("unhandled rejection", reason);
+});
+process.on("uncaughtException", (err) => {
+  logError("uncaught exception", err);
+  process.exit(1);
+});
 
 const BASE_INSTRUCTIONS = [
   "Design and debug Renovate configurations interactively.",

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,0 +1,22 @@
+// stderr-only logging for the MCP stdio server.
+// stdout carries JSON-RPC frames — anything written there corrupts the next
+// message the client receives, so error output must never go through console.log.
+
+const PREFIX = "[renovate-mcp]";
+
+function formatReason(reason: unknown): string {
+  if (reason instanceof Error) {
+    return reason.stack ?? `${reason.name}: ${reason.message}`;
+  }
+  if (typeof reason === "string") return reason;
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return String(reason);
+  }
+}
+
+export function logError(message: string, reason?: unknown): void {
+  const suffix = reason === undefined ? "" : `: ${formatReason(reason)}`;
+  process.stderr.write(`${PREFIX} ${message}${suffix}\n`);
+}

--- a/test/unit/log.test.ts
+++ b/test/unit/log.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { logError } from "../../src/lib/log.js";
+
+describe("logError", () => {
+  let stderrWrite: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrWrite.mockRestore();
+  });
+
+  it("writes to stderr with a recognizable prefix", () => {
+    logError("hello");
+    expect(stderrWrite).toHaveBeenCalledOnce();
+    expect(stderrWrite.mock.calls[0]?.[0]).toBe("[renovate-mcp] hello\n");
+  });
+
+  it("appends an Error's stack when provided as reason", () => {
+    const err = new Error("boom");
+    logError("uncaught exception", err);
+    const out = stderrWrite.mock.calls[0]?.[0] as string;
+    expect(out.startsWith("[renovate-mcp] uncaught exception: ")).toBe(true);
+    expect(out).toContain("boom");
+    expect(out.endsWith("\n")).toBe(true);
+  });
+
+  it("stringifies non-Error reasons", () => {
+    logError("unhandled rejection", { code: 42 });
+    expect(stderrWrite.mock.calls[0]?.[0]).toBe(
+      `[renovate-mcp] unhandled rejection: {"code":42}\n`,
+    );
+  });
+
+  it("falls back to String() for values JSON.stringify cannot handle", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    logError("unhandled rejection", circular);
+    const out = stderrWrite.mock.calls[0]?.[0] as string;
+    expect(out.startsWith("[renovate-mcp] unhandled rejection: ")).toBe(true);
+    expect(out).toContain("[object Object]");
+  });
+
+  it("never writes to stdout", () => {
+    const stdoutWrite = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    try {
+      logError("anything", new Error("x"));
+      expect(stdoutWrite).not.toHaveBeenCalled();
+    } finally {
+      stdoutWrite.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Register top-level `unhandledRejection` and `uncaughtException` handlers in `src/index.ts` that write to stderr only — stdout carries JSON-RPC frames in the MCP stdio transport, so an error log on stdout would corrupt the next message the client receives.
- Add a tiny `src/lib/log.ts` helper (`logError(message, reason?)`) that writes a `[renovate-mcp]` prefixed line to stderr, formatting `Error` instances with their stack and falling back to `JSON.stringify` / `String()` for other values.
- `uncaughtException` exits with code 1 — the process state is undefined after one, so failing fast and letting the client reconnect is safer than staying alive on corrupted internals.

Closes #126.

## Test plan
- [x] `npm run typecheck`
- [x] `vitest run test/unit/log.test.ts` — 5 new passing cases covering prefix, Error stack, JSON-stringifiable reasons, the circular-reference fallback, and the invariant that `logError` never writes to stdout
- [x] `vitest run test/unit` — all 240 unit tests pass
- [x] `vitest run test/integration` — all 69 integration tests pass (no regressions in the stdio handshake)