### PR TITLE
fix(security): refuse to follow pre-existing symlinks in write_config temp path

### DIFF
--- a/src/tools/writeConfig.ts
+++ b/src/tools/writeConfig.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import path from "node:path";
 import { promises as fs } from "node:fs";
+import { randomUUID } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { run, resolveRenovateTool, formatMissingBinaryError } from "../lib/renovateCli.js";
 
@@ -61,9 +62,12 @@ export function registerWriteConfig(server: McpServer): void {
       }
 
       const payload = JSON.stringify(config, null, 2) + "\n";
-      const tmp = `${target}.renovate-mcp-tmp`;
+      // Randomize the suffix so two concurrent writes don't collide, and use
+      // `flag: "wx"` (O_CREAT|O_EXCL) so a pre-existing symlink at the temp
+      // path is refused with EEXIST instead of silently followed (issue #129).
+      const tmp = `${target}.renovate-mcp-tmp-${randomUUID()}`;
       await fs.mkdir(path.dirname(target), { recursive: true });
-      await fs.writeFile(tmp, payload);
+      await fs.writeFile(tmp, payload, { flag: "wx", mode: 0o600 });
 
       try {
         let valid = false;

--- a/test/integration/writeConfig.test.ts
+++ b/test/integration/writeConfig.test.ts
@@ -98,6 +98,86 @@ describe("write_config", () => {
     expect(files.some((f) => f.endsWith(".renovate-mcp-tmp"))).toBe(false);
   });
 
+  it("does not follow a pre-existing symlink at the legacy temp path (issue #129)", async () => {
+    // Threat model: an attacker plants a symlink at the deterministic legacy
+    // temp path pointing at a sentinel outside the repo. Two combined defenses
+    // make this safe: (1) the temp suffix is randomized so the attacker can't
+    // predict the actual write target, (2) the writeFile uses `flag: "wx"` so
+    // even if they could, O_EXCL refuses to follow a pre-existing entry.
+    const validator = await makeFakeValidator(repo, "fake-pass.mjs", 0);
+    session = await startServer({ RENOVATE_CONFIG_VALIDATOR_BIN: validator });
+
+    const outside = await mkdtemp(
+      path.join(
+        tmpdir(),
+        `rmcp-${path.basename(import.meta.url, ".ts")}-${process.pid}-sentinel-`,
+      ),
+    );
+    try {
+      const sentinel = path.join(outside, "sentinel.txt");
+      const sentinelContent = "do-not-overwrite";
+      await writeFile(sentinel, sentinelContent);
+      const legacyTmp = path.join(repo, "renovate.json.renovate-mcp-tmp");
+      await symlink(sentinel, legacyTmp);
+
+      const res = await session.request<{
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+      }>("tools/call", {
+        name: "write_config",
+        arguments: {
+          repoPath: repo,
+          config: { extends: ["config:recommended"] },
+        },
+      });
+
+      expect(res.result?.isError).toBeFalsy();
+
+      // The sentinel must be untouched — the LLM-shaped payload must never
+      // have been written through the symlink.
+      expect(await readFile(sentinel, "utf8")).toBe(sentinelContent);
+
+      // The planted symlink itself is unrelated to the actual (randomized)
+      // temp path, so it stays in place.
+      const files = await readdir(repo);
+      expect(files).toContain("renovate.json.renovate-mcp-tmp");
+      expect(files).toContain("renovate.json");
+      // No tmp file leaks under the random suffix either.
+      expect(
+        files.filter((f) => f.startsWith("renovate.json.renovate-mcp-tmp-")),
+      ).toHaveLength(0);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("does not collide on the temp suffix when called concurrently (issue #129)", async () => {
+    const validator = await makeFakeValidator(repo, "fake-pass.mjs", 0);
+    session = await startServer({ RENOVATE_CONFIG_VALIDATOR_BIN: validator });
+
+    const calls = Array.from({ length: 5 }, (_, i) =>
+      session.request<{
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+      }>("tools/call", {
+        name: "write_config",
+        arguments: {
+          repoPath: repo,
+          config: { extends: ["config:recommended"], _i: i },
+        },
+      }),
+    );
+    const results = await Promise.all(calls);
+    for (const res of results) {
+      expect(res.result?.isError).toBeFalsy();
+    }
+
+    const files = await readdir(repo);
+    expect(
+      files.filter((f) => f.startsWith("renovate.json.renovate-mcp-tmp")),
+    ).toHaveLength(0);
+  });
+
   it("rejects a filename whose resolved parent escapes repoPath via a symlink", async () => {
     session = await startServer();
 


### PR DESCRIPTION
## Summary
- Closes #129. The pre-validation temp file in `write_config` was opened with the default `fs.writeFile` flag (`O_CREAT|O_WRONLY|O_TRUNC`, no `O_NOFOLLOW`), which silently follows symlinks. A pre-existing symlink at the deterministic legacy temp path (`renovate.json.renovate-mcp-tmp`) — e.g. shipped via a malicious fork/PR — would have caused an LLM-shaped JSON payload to land at whatever target the symlink pointed at (`~/.ssh/authorized_keys`, `~/.bashrc`, etc.).
- Fix: open the temp file with `flag: 'wx'` (`O_CREAT|O_EXCL|O_WRONLY`) so `O_EXCL` refuses a pre-existing entry with `EEXIST` instead of following it, and `mode: 0o600`. Randomize the suffix with `randomUUID()` so concurrent calls don't collide on the temp suffix and the path isn't predictable.
- The atomic-rename design from the file's docstring is preserved; only the temp-path semantics change.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` (311 tests, 23 files) passes
- [x] New integration test plants a pre-existing symlink at the legacy temp path pointing to an outside-the-repo sentinel and asserts the sentinel content and the symlink itself are unchanged after `write_config` succeeds (the random suffix means we never touch the planted symlink; the `wx` flag is the load-bearing defense if someone could predict it).
- [x] New integration test fires 5 concurrent `write_config` calls and asserts none collide on the temp suffix and no temp files leak.