### PR TITLE
fix(security): cap tool input sizes to prevent DoS via oversized inputs

### DIFF
--- a/src/lib/inputLimits.ts
+++ b/src/lib/inputLimits.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+// Centralized input-size caps for every tool schema. These exist to refuse
+// pathologically large inputs (DoS via 100 MB blobs) before any business
+// logic runs. Caps are intentionally generous — real-world inputs are orders
+// of magnitude smaller — so the only way to trip them is intent or a buggy
+// caller.
+
+export const PATH_MAX_BYTES = 4096;
+export const TOKEN_MAX_BYTES = 1024;
+export const ENDPOINT_MAX_BYTES = 2048;
+export const REPOSITORY_MAX_BYTES = 256;
+export const FILENAME_MAX_BYTES = 512;
+export const CONFIG_JSON_MAX_BYTES = 1_000_000;
+export const REPORT_JSON_MAX_BYTES = 10_000_000;
+export const HOST_RULES_MAX_ITEMS = 256;
+export const HOST_RULE_JSON_MAX_BYTES = 64_000;
+
+export const pathString = (description: string) =>
+  z.string().max(PATH_MAX_BYTES).describe(description);
+
+export const tokenString = (description: string) =>
+  z.string().max(TOKEN_MAX_BYTES).describe(description);
+
+export const endpointString = (description: string) =>
+  z.string().max(ENDPOINT_MAX_BYTES).describe(description);
+
+export const repositoryString = (description: string) =>
+  z.string().max(REPOSITORY_MAX_BYTES).describe(description);
+
+export const filenameString = (description: string) =>
+  z.string().max(FILENAME_MAX_BYTES).describe(description);
+
+const refineJsonSize =
+  (limit: number) =>
+  (value: unknown): boolean => {
+    try {
+      return JSON.stringify(value).length <= limit;
+    } catch {
+      return false;
+    }
+  };
+
+export const configRecord = (description: string) =>
+  z
+    .record(z.string(), z.unknown())
+    .refine(refineJsonSize(CONFIG_JSON_MAX_BYTES), {
+      message: `Config object exceeds ${CONFIG_JSON_MAX_BYTES} bytes when serialized`,
+    })
+    .describe(description);
+
+export const reportRecord = (description: string) =>
+  z
+    .record(z.string(), z.unknown())
+    .refine(refineJsonSize(REPORT_JSON_MAX_BYTES), {
+      message: `Report object exceeds ${REPORT_JSON_MAX_BYTES} bytes when serialized`,
+    })
+    .describe(description);
+
+export const hostRuleRecord = (description: string) =>
+  z
+    .record(z.string(), z.unknown())
+    .refine(refineJsonSize(HOST_RULE_JSON_MAX_BYTES), {
+      message: `hostRule entry exceeds ${HOST_RULE_JSON_MAX_BYTES} bytes when serialized`,
+    })
+    .describe(description);

--- a/src/tools/dryRun.ts
+++ b/src/tools/dryRun.ts
@@ -18,12 +18,18 @@ import {
   extractRenovateLogMsg,
   buildDryRunHeartbeatMessage,
 } from "../lib/dryRunProgress.js";
+import {
+  HOST_RULES_MAX_ITEMS,
+  endpointString,
+  hostRuleRecord,
+  pathString,
+  repositoryString,
+  tokenString,
+} from "../lib/inputLimits.js";
 
-const hostRuleSchema = z
-  .record(z.string(), z.unknown())
-  .describe(
-    "A single Renovate hostRule (matchHost, hostType, username, password, token, …). Structure is not validated here — Renovate's own config loader checks it when the temp file is read.",
-  );
+const hostRuleSchema = hostRuleRecord(
+  "A single Renovate hostRule (matchHost, hostType, username, password, token, …). Structure is not validated here — Renovate's own config loader checks it when the temp file is read.",
+);
 
 /**
  * Walk Renovate's JSON report looking for `problems` arrays and collect the
@@ -107,11 +113,9 @@ export function registerDryRun(server: McpServer): void {
       description:
         "Run Renovate in dry-run mode to preview what it would do — no PRs opened, no git pushes. Returns a structured JSON report plus a top-level `ok` boolean (false when the CLI failed OR the report records a validation/error-level problem, even if the exit code was 0).\n\nDefault mode runs `--platform=local` against the filesystem at `repoPath`. If your config extends `local>…` presets, pass `platform` (`github` or `gitlab`), `endpoint` (API base URL), `token`, and `repository` to run as a real platform client that can actually fetch those presets — Renovate still runs with `--dry-run`, so no PRs are opened. If you only need `gitlab>…` / `github>…` presets resolved against a self-hosted host (not a full remote run), pass just `endpoint` (and `token` if needed) while leaving `platform` unset — both flow through to Renovate in local mode too, which is enough to redirect those preset shortcuts away from the public defaults. The tool preflight-checks for `local>` presets under `--platform=local` (in `lookup` and `full` modes) and fails fast with remediation guidance rather than spawning a Renovate run that would fail opaquely with `config-validation`. The preflight is skipped for `dryRunMode=extract` so manifest-only extraction can be attempted regardless.\n\nWhen the `token` input is omitted, the tool falls back to `RENOVATE_TOKEN` from the MCP server's env, then to `GITLAB_TOKEN` (when `platform=gitlab`) or `GITHUB_TOKEN` (when `platform=github`) — whichever is auto-translated to `RENOVATE_TOKEN` for the spawned Renovate CLI. This matches the precedence `resolve_config` already uses, so a single `GITLAB_TOKEN` in `.mcp.json` works for both tools. For a remote-platform run, an actionable preflight error is returned before spawning Renovate when no token can be resolved at all.\n\nCredentials for private registries (e.g. `COMPOSER_AUTH` for Packagist/Satis proxies, `NPM_TOKEN` / `.npmrc` for npm, Docker registry creds, `RENOVATE_HOST_RULES` for anything else) must be set on the MCP server process itself — via the `env` key in `claude_desktop_config.json` / `.mcp.json`, not your shell, since the MCP server runs as a child of Claude and does not inherit shell env. Alternatively, encode credentials as `hostRules` in the Renovate config, or pass them per-call via the `hostRules` input on this tool (written to a mode-0600 temp file that is cleaned up after the run; token/password values — including the platform `token` input — are scrubbed from `logTail` and `problems`). Per-call `hostRules` are appended to any the repo's own config already declares. If a lookup can't auth to a registry, Renovate often reports 0 updates without a loud error; when that happens this tool surfaces detected auth failures under `problems` in the output so callers can distinguish a genuine \"no updates\" from a silent registry-auth failure.",
       inputSchema: {
-        repoPath: z
-          .string()
-          .describe(
-            "Absolute path to the repository root. Required for the default `platform=local` mode. When `platform` is overridden (e.g. `gitlab` / `github`), Renovate runs against the remote `repository` instead — `repoPath` is still used as the child's working directory but its manifest files are ignored.",
-          ),
+        repoPath: pathString(
+          "Absolute path to the repository root. Required for the default `platform=local` mode. When `platform` is overridden (e.g. `gitlab` / `github`), Renovate runs against the remote `repository` instead — `repoPath` is still used as the child's working directory but its manifest files are ignored.",
+        ),
         dryRunMode: z
           .enum(["extract", "lookup", "full"])
           .default("full")
@@ -132,26 +136,18 @@ export function registerDryRun(server: McpServer): void {
           .describe(
             "Renovate platform to run as. When unset, falls back to `RENOVATE_PLATFORM` from the MCP server's env (if it's one of `local`/`github`/`gitlab`), then to `local`. Default `local` runs against the filesystem at `repoPath`. Set `github` or `gitlab` (with `endpoint` + `token` + `repository`) to run a full remote dry-run — this is what you need when your config extends `local>` presets that live on a private GitHub Enterprise / self-hosted GitLab. Still no PRs opened because `--dry-run` is always set.",
           ),
-        endpoint: z
-          .string()
-          .optional()
-          .describe(
-            "Custom API base URL (e.g. `https://gitlab.example.com/api/v4/` or `https://ghe.example.com/api/v3/`). Forwarded as `--endpoint` regardless of `platform`: required for non-default GitHub/GitLab hosts when `platform=github`/`gitlab`, and also useful in the default `platform=local` mode to point `gitlab>…` / `github>…` preset shortcuts at a self-hosted host instead of the public defaults.",
-          ),
-        token: z
-          .string()
-          .optional()
-          .describe(
-            "Auth token, exported as `RENOVATE_TOKEN` to the child. Scrubbed from any log output this tool returns. Used both for the platform connection (when `platform` is `github`/`gitlab`) and for preset resolution against private repos (e.g. when fetching a `gitlab>…` preset from a private project while in local mode). When omitted, falls back to `RENOVATE_TOKEN` from MCP env, then to `GITLAB_TOKEN` (when `platform=gitlab`) or `GITHUB_TOKEN` (when `platform=github`) — same precedence as `resolve_config`. Platform-specific fallbacks only kick in when the matching remote platform is selected; in `platform=local` they're ignored.",
-          ),
-        repository: z
-          .string()
-          .optional()
-          .describe(
-            "Identifier of the repository Renovate should operate on, passed as a positional argument (Renovate has no `--repository` flag). For GitHub: `owner/repo`. For GitLab: `group/project` or a nested-group path like `group/subgroup/project` — both are accepted. Required when `platform` is `github`/`gitlab`. Ignored when `platform=local`.",
-          ),
+        endpoint: endpointString(
+          "Custom API base URL (e.g. `https://gitlab.example.com/api/v4/` or `https://ghe.example.com/api/v3/`). Forwarded as `--endpoint` regardless of `platform`: required for non-default GitHub/GitLab hosts when `platform=github`/`gitlab`, and also useful in the default `platform=local` mode to point `gitlab>…` / `github>…` preset shortcuts at a self-hosted host instead of the public defaults.",
+        ).optional(),
+        token: tokenString(
+          "Auth token, exported as `RENOVATE_TOKEN` to the child. Scrubbed from any log output this tool returns. Used both for the platform connection (when `platform` is `github`/`gitlab`) and for preset resolution against private repos (e.g. when fetching a `gitlab>…` preset from a private project while in local mode). When omitted, falls back to `RENOVATE_TOKEN` from MCP env, then to `GITLAB_TOKEN` (when `platform=gitlab`) or `GITHUB_TOKEN` (when `platform=github`) — same precedence as `resolve_config`. Platform-specific fallbacks only kick in when the matching remote platform is selected; in `platform=local` they're ignored.",
+        ).optional(),
+        repository: repositoryString(
+          "Identifier of the repository Renovate should operate on, passed as a positional argument (Renovate has no `--repository` flag). For GitHub: `owner/repo`. For GitLab: `group/project` or a nested-group path like `group/subgroup/project` — both are accepted. Required when `platform` is `github`/`gitlab`. Ignored when `platform=local`.",
+        ).optional(),
         hostRules: z
           .array(hostRuleSchema)
+          .max(HOST_RULES_MAX_ITEMS)
           .optional()
           .describe(
             "Optional per-invocation Renovate hostRules for private registry auth. Written to a mode-0600 temp file that is passed via the RENOVATE_CONFIG_FILE env var and deleted after the run. Token/password values are scrubbed from any log output this tool returns. Appended to (not replacing) any hostRules declared in the repo's own config.",

--- a/src/tools/dryRunDiff.ts
+++ b/src/tools/dryRunDiff.ts
@@ -1,12 +1,10 @@
-import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { diffDryRunReports } from "../lib/dryRunDiff.js";
+import { reportRecord } from "../lib/inputLimits.js";
 
-const reportShape = z
-  .record(z.string(), z.unknown())
-  .describe(
-    "A Renovate dry-run report. Pass either the raw report (an object with a `repositories` key) or the full `dry_run` tool summary (an object with a `report` key); the tool unwraps `report` automatically.",
-  );
+const reportShape = reportRecord(
+  "A Renovate dry-run report. Pass either the raw report (an object with a `repositories` key) or the full `dry_run` tool summary (an object with a `report` key); the tool unwraps `report` automatically.",
+);
 
 export function registerDryRunDiff(server: McpServer): void {
   server.registerTool(

--- a/src/tools/explainConfig.ts
+++ b/src/tools/explainConfig.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { locateConfig } from "../lib/configLocations.js";
 import { explainConfig } from "../lib/configExplainer.js";
+import { configRecord, endpointString, pathString } from "../lib/inputLimits.js";
 
 const MERGE_QUALITY = "preview" as const;
 const MERGE_DISCLAIMER =
@@ -15,28 +16,21 @@ export function registerExplainConfig(server: McpServer): void {
       description:
         "Inverse of resolve_config: walk the same preset tree, but annotate every leaf field with the chain of presets that touched it. Each leaf in `explanation` carries `{ value, setBy }` where `setBy` lists every contribution in merge order — last entry wins for scalars; for arrays each entry adds its own slice. The `<own>` source means the value came from the user's input config (siblings of `extends`); other sources are preset references as written in `extends`. Use this to trace surprises like \"why is `prCreation` set to 'not-pending'?\". Pure analysis: same offline-by-default behaviour as resolve_config, plus the same `externalPresets` / `endpoint` / `platform` opt-ins. Pass `repoPath` (reads the repo's config) or `configContent` (an inline config). For full-fidelity output, run dry_run instead.",
       inputSchema: {
-        repoPath: z
-          .string()
-          .optional()
-          .describe(
-            "Absolute path to the repository root. The tool will locate the repo's renovate config automatically.",
-          ),
-        configContent: z
-          .record(z.string(), z.unknown())
-          .optional()
-          .describe("Inline config object to explain — use instead of repoPath."),
+        repoPath: pathString(
+          "Absolute path to the repository root. The tool will locate the repo's renovate config automatically.",
+        ).optional(),
+        configContent: configRecord(
+          "Inline config object to explain — use instead of repoPath.",
+        ).optional(),
         externalPresets: z
           .boolean()
           .optional()
           .describe(
             "When true, fetch external presets (github>, gitlab>) over HTTPS — same credentials and behaviour as resolve_config. Default false.",
           ),
-        endpoint: z
-          .string()
-          .optional()
-          .describe(
-            "API base URL for github>/gitlab> fetches. Use for GitHub Enterprise or self-hosted GitLab — same semantics as resolve_config.",
-          ),
+        endpoint: endpointString(
+          "API base URL for github>/gitlab> fetches. Use for GitHub Enterprise or self-hosted GitLab — same semantics as resolve_config.",
+        ).optional(),
         platform: z
           .enum(["github", "gitlab"])
           .optional()

--- a/src/tools/lintConfig.ts
+++ b/src/tools/lintConfig.ts
@@ -1,9 +1,9 @@
-import { z } from "zod";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { lintConfig } from "../lib/configLinter.js";
+import { configRecord, pathString } from "../lib/inputLimits.js";
 
 export function registerLintConfig(server: McpServer): void {
   server.registerTool(
@@ -13,14 +13,10 @@ export function registerLintConfig(server: McpServer): void {
       description:
         "Run a semantic lint pass over a Renovate config. Complements validate_config: schema validation catches structural bugs, this catches Renovate-specific footguns schema validation misses — malformed '/…/' regex patterns in fields like matchPackageNames, matchDepNames, matchSourceUrls, matchCurrentVersion, plus unknown manager names in matchManagers / excludeManagers (typos that Renovate silently ignores). Offline; does not shell out. Pass either configPath (file on disk, JSON or JSON5) or configContent (inline object).",
       inputSchema: {
-        configPath: z
-          .string()
-          .optional()
-          .describe("Absolute path to a config file to lint (JSON or JSON5)"),
-        configContent: z
-          .record(z.string(), z.unknown())
-          .optional()
-          .describe("Inline config object to lint"),
+        configPath: pathString(
+          "Absolute path to a config file to lint (JSON or JSON5)",
+        ).optional(),
+        configContent: configRecord("Inline config object to lint").optional(),
       },
     },
     async ({ configPath, configContent }) => {

--- a/src/tools/previewCustomManager.ts
+++ b/src/tools/previewCustomManager.ts
@@ -4,6 +4,7 @@ import {
   previewCustomManager,
   type CustomManager,
 } from "../lib/customManagerPreview.js";
+import { pathString } from "../lib/inputLimits.js";
 
 const managerSchema = z
   .object({
@@ -41,7 +42,7 @@ export function registerPreviewCustomManager(server: McpServer): void {
         "Run the `dry_run` tool afterwards for full-fidelity confirmation.",
       ].join("\n"),
       inputSchema: {
-        repoPath: z.string().describe("Absolute path to the repository root"),
+        repoPath: pathString("Absolute path to the repository root"),
         manager: managerSchema.describe(
           "A single Renovate customManagers entry. NOTE: `fileMatch` is an array of REGEX strings matched against POSIX-style relative paths (not globs).",
         ),

--- a/src/tools/readConfig.ts
+++ b/src/tools/readConfig.ts
@@ -1,6 +1,6 @@
-import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { locateConfig } from "../lib/configLocations.js";
+import { pathString } from "../lib/inputLimits.js";
 
 export function registerReadConfig(server: McpServer): void {
   server.registerTool(
@@ -10,7 +10,7 @@ export function registerReadConfig(server: McpServer): void {
       description:
         "Locate and parse the Renovate configuration in a repository. Searches for renovate.json, renovate.json5, .renovaterc(.json|.json5), .github/renovate.json, .gitlab/renovate.json, and the 'renovate' field of package.json — in that priority order.",
       inputSchema: {
-        repoPath: z.string().describe("Absolute path to the repository root"),
+        repoPath: pathString("Absolute path to the repository root"),
       },
     },
     async ({ repoPath }) => {

--- a/src/tools/resolveConfig.ts
+++ b/src/tools/resolveConfig.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { locateConfig } from "../lib/configLocations.js";
 import { resolveConfig } from "../lib/presetResolver.js";
+import { configRecord, endpointString, pathString } from "../lib/inputLimits.js";
 
 const MERGE_QUALITY = "preview" as const;
 const MERGE_DISCLAIMER =
@@ -15,28 +16,21 @@ export function registerResolveConfig(server: McpServer): void {
       description:
         "Expand every preset referenced by `extends` and return the fully resolved config. Built-in presets resolve offline against the committed catalogue. Pass `externalPresets: true` to fetch `github>` and `gitlab>` presets over HTTPS (with optional `RENOVATE_TOKEN` — or `GITHUB_TOKEN` / `GITLAB_TOKEN` as platform-specific fallbacks — for private repos). For GitHub Enterprise or self-hosted GitLab, pass `endpoint` (API base URL, e.g. `https://ghe.example.com/api/v3` or `https://gitlab.example.com/api/v4`); pass `platform` in addition to route `local>` presets through the same endpoint. `bitbucket>`, `gitea>`, and npm presets are structurally unsupported and remain in `presetsUnresolved` regardless. Endpoint and platform are **tool inputs only** — env vars like `RENOVATE_ENDPOINT` are not read, since the MCP server runs under Claude rather than in your shell. Pass either `repoPath` (reads the repo's config) or `configContent` (an inline config object). The response includes `mergeQuality: \"preview\"` plus a `disclaimer` and a `warnings` array — preset merging here is a close approximation of Renovate's rules rather than bit-identical, and Handlebars expressions other than `{{argN}}` are left verbatim; run `dry_run` for authoritative output.",
       inputSchema: {
-        repoPath: z
-          .string()
-          .optional()
-          .describe(
-            "Absolute path to the repository root. The tool will locate the repo's renovate config automatically.",
-          ),
-        configContent: z
-          .record(z.string(), z.unknown())
-          .optional()
-          .describe("Inline config object to resolve — use instead of repoPath."),
+        repoPath: pathString(
+          "Absolute path to the repository root. The tool will locate the repo's renovate config automatically.",
+        ).optional(),
+        configContent: configRecord(
+          "Inline config object to resolve — use instead of repoPath.",
+        ).optional(),
         externalPresets: z
           .boolean()
           .optional()
           .describe(
             "When true, fetch external presets (github>, gitlab>) over HTTPS. Credentials come from RENOVATE_TOKEN (preferred, matches Renovate's own convention) or GITHUB_TOKEN / GITLAB_TOKEN as platform-specific fallbacks, set on the MCP server process — via the `env` key in claude_desktop_config.json / .mcp.json, not your shell, since the MCP server runs as a child of Claude and does not inherit shell env. Default false.",
           ),
-        endpoint: z
-          .string()
-          .optional()
-          .describe(
-            "API base URL for github>/gitlab> fetches. Use for GitHub Enterprise (e.g. https://ghe.example.com/api/v3) or self-hosted GitLab (e.g. https://gitlab.example.com/api/v4). Defaults to https://api.github.com and https://gitlab.com/api/v4.",
-          ),
+        endpoint: endpointString(
+          "API base URL for github>/gitlab> fetches. Use for GitHub Enterprise (e.g. https://ghe.example.com/api/v3) or self-hosted GitLab (e.g. https://gitlab.example.com/api/v4). Defaults to https://api.github.com and https://gitlab.com/api/v4.",
+        ).optional(),
         platform: z
           .enum(["github", "gitlab"])
           .optional()

--- a/src/tools/validateConfig.ts
+++ b/src/tools/validateConfig.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { run, resolveRenovateTool, formatMissingBinaryError } from "../lib/renovateCli.js";
+import { configRecord, pathString } from "../lib/inputLimits.js";
 
 export function registerValidateConfig(server: McpServer): void {
   server.registerTool(
@@ -14,14 +15,10 @@ export function registerValidateConfig(server: McpServer): void {
       description:
         "Validate a Renovate configuration against the official schema using renovate-config-validator. Pass either configPath (file on disk) or configContent (inline JSON object). Returns validation output and a boolean `valid`.",
       inputSchema: {
-        configPath: z
-          .string()
-          .optional()
-          .describe("Absolute path to a config file to validate"),
-        configContent: z
-          .record(z.string(), z.unknown())
-          .optional()
-          .describe("Inline config object to validate (written to a temp file)"),
+        configPath: pathString("Absolute path to a config file to validate").optional(),
+        configContent: configRecord(
+          "Inline config object to validate (written to a temp file)",
+        ).optional(),
         strict: z
           .boolean()
           .optional()

--- a/src/tools/writeConfig.ts
+++ b/src/tools/writeConfig.ts
@@ -4,6 +4,7 @@ import { promises as fs } from "node:fs";
 import { randomUUID } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { run, resolveRenovateTool, formatMissingBinaryError } from "../lib/renovateCli.js";
+import { configRecord, filenameString, pathString } from "../lib/inputLimits.js";
 
 // Resolve symlinks in `p`, walking up to the nearest existing ancestor when
 // tail components don't exist yet (e.g. a new subdir we're about to mkdir).
@@ -34,12 +35,11 @@ export function registerWriteConfig(server: McpServer): void {
       description:
         "Write a Renovate config to disk. Runs renovate-config-validator first — refuses to write if validation fails unless force=true.",
       inputSchema: {
-        repoPath: z.string().describe("Absolute path to the repository root"),
-        config: z.record(z.string(), z.unknown()).describe("The Renovate config object"),
-        filename: z
-          .string()
-          .default("renovate.json")
-          .describe("Target filename relative to repoPath (default renovate.json)"),
+        repoPath: pathString("Absolute path to the repository root"),
+        config: configRecord("The Renovate config object"),
+        filename: filenameString(
+          "Target filename relative to repoPath (default renovate.json)",
+        ).default("renovate.json"),
         force: z
           .boolean()
           .default(false)

--- a/test/unit/inputLimits.test.ts
+++ b/test/unit/inputLimits.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import { z, type ZodRawShape } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  CONFIG_JSON_MAX_BYTES,
+  ENDPOINT_MAX_BYTES,
+  FILENAME_MAX_BYTES,
+  HOST_RULES_MAX_ITEMS,
+  HOST_RULE_JSON_MAX_BYTES,
+  PATH_MAX_BYTES,
+  REPORT_JSON_MAX_BYTES,
+  REPOSITORY_MAX_BYTES,
+  TOKEN_MAX_BYTES,
+  configRecord,
+  endpointString,
+  filenameString,
+  hostRuleRecord,
+  pathString,
+  repositoryString,
+  reportRecord,
+  tokenString,
+} from "../../src/lib/inputLimits.js";
+
+import { registerDryRun } from "../../src/tools/dryRun.js";
+import { registerDryRunDiff } from "../../src/tools/dryRunDiff.js";
+import { registerExplainConfig } from "../../src/tools/explainConfig.js";
+import { registerLintConfig } from "../../src/tools/lintConfig.js";
+import { registerPreviewCustomManager } from "../../src/tools/previewCustomManager.js";
+import { registerReadConfig } from "../../src/tools/readConfig.js";
+import { registerResolveConfig } from "../../src/tools/resolveConfig.js";
+import { registerValidateConfig } from "../../src/tools/validateConfig.js";
+import { registerWriteConfig } from "../../src/tools/writeConfig.js";
+
+interface CapturedTool {
+  name: string;
+  inputSchema: z.ZodObject<ZodRawShape>;
+}
+
+function captureTool(register: (server: McpServer) => void): CapturedTool {
+  let captured: CapturedTool | null = null;
+  const fakeServer = {
+    registerTool: (
+      name: string,
+      config: { inputSchema: ZodRawShape },
+    ) => {
+      captured = { name, inputSchema: z.object(config.inputSchema) };
+    },
+  } as unknown as McpServer;
+  register(fakeServer);
+  if (!captured) throw new Error("register did not call registerTool");
+  return captured;
+}
+
+const oversizedString = (n: number) => "x".repeat(n + 1);
+const fatRecord = (jsonSize: number) => ({
+  blob: "y".repeat(jsonSize),
+});
+
+describe("inputLimits helpers", () => {
+  it("pathString rejects strings over PATH_MAX_BYTES", () => {
+    expect(pathString("p").safeParse(oversizedString(PATH_MAX_BYTES)).success).toBe(false);
+    expect(pathString("p").safeParse("x".repeat(PATH_MAX_BYTES)).success).toBe(true);
+  });
+
+  it("tokenString rejects strings over TOKEN_MAX_BYTES", () => {
+    expect(tokenString("t").safeParse(oversizedString(TOKEN_MAX_BYTES)).success).toBe(false);
+    expect(tokenString("t").safeParse("x".repeat(TOKEN_MAX_BYTES)).success).toBe(true);
+  });
+
+  it("endpointString rejects strings over ENDPOINT_MAX_BYTES", () => {
+    expect(endpointString("e").safeParse(oversizedString(ENDPOINT_MAX_BYTES)).success).toBe(false);
+    expect(endpointString("e").safeParse("x".repeat(ENDPOINT_MAX_BYTES)).success).toBe(true);
+  });
+
+  it("repositoryString rejects strings over REPOSITORY_MAX_BYTES", () => {
+    expect(
+      repositoryString("r").safeParse(oversizedString(REPOSITORY_MAX_BYTES)).success,
+    ).toBe(false);
+    expect(repositoryString("r").safeParse("x".repeat(REPOSITORY_MAX_BYTES)).success).toBe(true);
+  });
+
+  it("filenameString rejects strings over FILENAME_MAX_BYTES", () => {
+    expect(
+      filenameString("f").safeParse(oversizedString(FILENAME_MAX_BYTES)).success,
+    ).toBe(false);
+    expect(filenameString("f").safeParse("x".repeat(FILENAME_MAX_BYTES)).success).toBe(true);
+  });
+
+  it("configRecord rejects records whose JSON size exceeds CONFIG_JSON_MAX_BYTES", () => {
+    const reject = configRecord("c").safeParse(fatRecord(CONFIG_JSON_MAX_BYTES + 1));
+    expect(reject.success).toBe(false);
+    const accept = configRecord("c").safeParse({ extends: ["config:recommended"] });
+    expect(accept.success).toBe(true);
+  });
+
+  it("reportRecord rejects records whose JSON size exceeds REPORT_JSON_MAX_BYTES", () => {
+    const reject = reportRecord("r").safeParse(fatRecord(REPORT_JSON_MAX_BYTES + 1));
+    expect(reject.success).toBe(false);
+    const accept = reportRecord("r").safeParse({ repositories: [] });
+    expect(accept.success).toBe(true);
+  });
+
+  it("hostRuleRecord rejects records whose JSON size exceeds HOST_RULE_JSON_MAX_BYTES", () => {
+    const reject = hostRuleRecord("h").safeParse(fatRecord(HOST_RULE_JSON_MAX_BYTES + 1));
+    expect(reject.success).toBe(false);
+    const accept = hostRuleRecord("h").safeParse({
+      matchHost: "example.com",
+      token: "t",
+    });
+    expect(accept.success).toBe(true);
+  });
+});
+
+describe("tool input schemas — DoS caps", () => {
+  it("read_config: rejects oversized repoPath", () => {
+    const tool = captureTool(registerReadConfig);
+    const res = tool.inputSchema.safeParse({ repoPath: oversizedString(PATH_MAX_BYTES) });
+    expect(res.success).toBe(false);
+  });
+
+  it("validate_config: rejects oversized configPath and oversized configContent", () => {
+    const tool = captureTool(registerValidateConfig);
+    expect(
+      tool.inputSchema.safeParse({ configPath: oversizedString(PATH_MAX_BYTES) }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({ configContent: fatRecord(CONFIG_JSON_MAX_BYTES + 1) }).success,
+    ).toBe(false);
+  });
+
+  it("lint_config: rejects oversized configPath and oversized configContent", () => {
+    const tool = captureTool(registerLintConfig);
+    expect(
+      tool.inputSchema.safeParse({ configPath: oversizedString(PATH_MAX_BYTES) }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({ configContent: fatRecord(CONFIG_JSON_MAX_BYTES + 1) }).success,
+    ).toBe(false);
+  });
+
+  it("resolve_config: rejects oversized repoPath, endpoint, and configContent", () => {
+    const tool = captureTool(registerResolveConfig);
+    expect(
+      tool.inputSchema.safeParse({ repoPath: oversizedString(PATH_MAX_BYTES) }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({ endpoint: oversizedString(ENDPOINT_MAX_BYTES) }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({ configContent: fatRecord(CONFIG_JSON_MAX_BYTES + 1) }).success,
+    ).toBe(false);
+  });
+
+  it("explain_config: rejects oversized repoPath, endpoint, and configContent", () => {
+    const tool = captureTool(registerExplainConfig);
+    expect(
+      tool.inputSchema.safeParse({ repoPath: oversizedString(PATH_MAX_BYTES) }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({ endpoint: oversizedString(ENDPOINT_MAX_BYTES) }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({ configContent: fatRecord(CONFIG_JSON_MAX_BYTES + 1) }).success,
+    ).toBe(false);
+  });
+
+  it("preview_custom_manager: rejects oversized repoPath", () => {
+    const tool = captureTool(registerPreviewCustomManager);
+    const res = tool.inputSchema.safeParse({
+      repoPath: oversizedString(PATH_MAX_BYTES),
+      manager: {
+        customType: "regex",
+        fileMatch: ["foo"],
+        matchStrings: ["bar"],
+      },
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("write_config: rejects oversized repoPath, filename, and config", () => {
+    const tool = captureTool(registerWriteConfig);
+    expect(
+      tool.inputSchema.safeParse({
+        repoPath: oversizedString(PATH_MAX_BYTES),
+        config: {},
+      }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({
+        repoPath: "/tmp/repo",
+        config: {},
+        filename: oversizedString(FILENAME_MAX_BYTES),
+      }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({
+        repoPath: "/tmp/repo",
+        config: fatRecord(CONFIG_JSON_MAX_BYTES + 1),
+      }).success,
+    ).toBe(false);
+  });
+
+  it("dry_run: rejects oversized repoPath, endpoint, token, repository, and overlong hostRules", () => {
+    const tool = captureTool(registerDryRun);
+    expect(
+      tool.inputSchema.safeParse({ repoPath: oversizedString(PATH_MAX_BYTES) }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({
+        repoPath: "/tmp/repo",
+        endpoint: oversizedString(ENDPOINT_MAX_BYTES),
+      }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({
+        repoPath: "/tmp/repo",
+        token: oversizedString(TOKEN_MAX_BYTES),
+      }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({
+        repoPath: "/tmp/repo",
+        repository: oversizedString(REPOSITORY_MAX_BYTES),
+      }).success,
+    ).toBe(false);
+
+    const tooManyRules = Array.from({ length: HOST_RULES_MAX_ITEMS + 1 }, () => ({
+      matchHost: "example.com",
+    }));
+    expect(
+      tool.inputSchema.safeParse({
+        repoPath: "/tmp/repo",
+        hostRules: tooManyRules,
+      }).success,
+    ).toBe(false);
+
+    expect(
+      tool.inputSchema.safeParse({
+        repoPath: "/tmp/repo",
+        hostRules: [fatRecord(HOST_RULE_JSON_MAX_BYTES + 1)],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("dry_run_diff: rejects oversized before / after reports", () => {
+    const tool = captureTool(registerDryRunDiff);
+    expect(
+      tool.inputSchema.safeParse({
+        before: fatRecord(REPORT_JSON_MAX_BYTES + 1),
+        after: { repositories: [] },
+      }).success,
+    ).toBe(false);
+    expect(
+      tool.inputSchema.safeParse({
+        before: { repositories: [] },
+        after: fatRecord(REPORT_JSON_MAX_BYTES + 1),
+      }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #133.
- Adds `src/lib/inputLimits.ts` with named caps and zod helpers (`pathString`, `tokenString`, `endpointString`, `repositoryString`, `filenameString`, `configRecord`, `reportRecord`, `hostRuleRecord`).
- Applies them across every tool: paths `.max(4096)`, tokens `.max(1024)`, endpoints `.max(2048)`, repository ids `.max(256)`, filenames `.max(512)`, config records refined to `<=1 MB` serialized, `dry_run_diff` reports refined to `<=10 MB`, `hostRules` array `.max(256)` with per-entry refine to `<=64 KB`.
- Oversized input is now refused at the schema layer with a clear MCP validation error before any handler runs.

## Approach
Used the recommended `.refine((v) => JSON.stringify(v).length <= CAP, ...)` form for record-shaped inputs so the existing API (callers pass objects, not strings) is preserved.

## Test plan
- [x] One unit test per schema asserting the cap fires (`test/unit/inputLimits.test.ts`, 17 tests).
- [x] `npm run typecheck` clean.
- [x] Full `npm test` suite passes (338/338).