### PR TITLE
fix(security): add least-privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ on:
       - '.github/workflows/publish.yml'
       - '.github/workflows/release.yaml'
 
+# Least-privilege default for the GITHUB_TOKEN. `actions/checkout` only
+# needs `contents: read`; nothing in this workflow writes back to the repo
+# or interacts with PRs/issues.
+permissions:
+  contents: read
+
 jobs:
   build-test:
     strategy:


### PR DESCRIPTION
## Summary
- Adds a top-level \`permissions: contents: read\` block to \`.github/workflows/ci.yml\`.
- Resolves CodeQL alert [#1](https://github.com/tibuntu/renovate-mcp/security/code-scanning/1) (\`actions/missing-workflow-permissions\`).

The build-test job only checks out the repo, runs npm install/typecheck/build/test, and uploads an artifact — none of which need write scopes on \`GITHUB_TOKEN\`, so \`contents: read\` is sufficient.

## Other open CodeQL alerts (not addressed here)
Alerts [#2](https://github.com/tibuntu/renovate-mcp/security/code-scanning/2) and [#3](https://github.com/tibuntu/renovate-mcp/security/code-scanning/3) flag \`js/redos\` on the regex \`^(a+)+b\$\` in \`test/unit/customManagerPreview.test.ts\`. Those are intentional catastrophic-backtracking fixtures used to verify the worker-based \`matchTimeoutMs\` aborts pathological regexes within budget — recommend dismissing as won't-fix on GitHub.

## Test plan
- [x] CI workflow YAML still parses and the new block is at workflow scope (above \`jobs:\`).
- [ ] Confirm CI run on this PR passes with the new permissions block (no step relies on a write scope).
- [ ] After merge, verify alert #1 closes automatically on the next CodeQL scan.