### PR TITLE
feat(resolve_config_diff): offline structural diff of two resolved configs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 MCP server that helps users design Renovate configurations interactively. TypeScript, Node ≥ 24 (aligns with Renovate's own engine requirement), built with `@modelcontextprotocol/sdk` 1.x, stdio transport.
 
-Surface is intentionally small: twelve tools (`check_setup`, `read_config`, `resolve_config`, `explain_config`, `preview_custom_manager`, `validate_config`, `lint_config`, `dry_run`, `dry_run_diff`, `migrate_config`, `write_config`, `get_version`) plus the `renovate://presets` resource family (namespace index, per-namespace listings, per-preset JSON). Don't grow this without a reason — the roadmap for expansion lives in the GitHub issues, not in ad-hoc additions.
+Surface is intentionally small: thirteen tools (`check_setup`, `read_config`, `resolve_config`, `explain_config`, `resolve_config_diff`, `preview_custom_manager`, `validate_config`, `lint_config`, `dry_run`, `dry_run_diff`, `migrate_config`, `write_config`, `get_version`) plus the `renovate://presets` resource family (namespace index, per-namespace listings, per-preset JSON). Don't grow this without a reason — the roadmap for expansion lives in the GitHub issues, not in ad-hoc additions.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Restart your client and try the prompt: *"List the namespaces available under `r
 
 ## Tools & resources
 
-Twelve tools and three resource templates. Each tool name below links to its full reference in [`docs/tools.md`](docs/tools.md).
+Thirteen tools and three resource templates. Each tool name below links to its full reference in [`docs/tools.md`](docs/tools.md).
 
 | Tool | Purpose |
 | --- | --- |
@@ -47,6 +47,7 @@ Twelve tools and three resource templates. Each tool name below links to its ful
 | [`read_config`](docs/tools.md#read_config) | Locate and parse a repo's Renovate config in Renovate's own discovery order. |
 | [`resolve_config`](docs/tools.md#resolve_config) | Expand every `extends` preset offline. Opt in to fetching `github>` / `gitlab>` presets over HTTPS. |
 | [`explain_config`](docs/tools.md#explain_config) | Inverse of `resolve_config`: annotate every leaf field with the chain of presets that set it. |
+| [`resolve_config_diff`](docs/tools.md#resolve_config_diff) | Offline structural diff of two fully-resolved configs — changed fields plus an order-insensitive set diff of array keys (`packageRules`, `customManagers`, …). The refactor-friendly counterpart to `dry_run_diff`. |
 | [`preview_custom_manager`](docs/tools.md#preview_custom_manager) | Preview a `customManagers` entry (regex or JSONata) against a local repo. Offline. |
 | [`validate_config`](docs/tools.md#validate_config) | Run `renovate-config-validator` against a file or inline object. |
 | [`lint_config`](docs/tools.md#lint_config) | Semantic lint pass for Renovate-specific footguns the schema validator declares valid. Offline. |
@@ -63,7 +64,7 @@ Twelve tools and three resource templates. Each tool name below links to its ful
 - **Linux or macOS.** Windows is not supported — `package.json` declares `"os": ["darwin", "linux"]`, so `npm i` surfaces an `EBADPLATFORM` warning on Windows and the server exits with a clear stderr message at startup. Use WSL2 or a Linux/macOS host instead.
 - **Node.js ≥ 24** (aligns with Renovate's own engine requirement).
 
-Renovate ships bundled — the `renovate` package is a runtime dependency, so `validate_config`, `dry_run`, and `write_config` work out of the box with no separate install. The offline tools (`read_config`, `resolve_config`, `explain_config`, `preview_custom_manager`, `lint_config`) never spawn Renovate at all.
+Renovate ships bundled — the `renovate` package is a runtime dependency, so `validate_config`, `dry_run`, and `write_config` work out of the box with no separate install. The offline tools (`read_config`, `resolve_config`, `explain_config`, `resolve_config_diff`, `preview_custom_manager`, `lint_config`) never spawn Renovate at all.
 
 **Optional env vars:**
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -14,6 +14,7 @@ Detailed reference for every tool and resource exposed by `renovate-mcp`. The [R
 - [`lint_config`](#lint_config)
 - [`dry_run`](#dry_run)
 - [`dry_run_diff`](#dry_run_diff)
+- [`resolve_config_diff`](#resolve_config_diff)
 - [`migrate_config`](#migrate_config)
 - [`write_config`](#write_config)
 
@@ -154,6 +155,21 @@ Each side accepts either the inline report (raw `{ repositories }` or a full `dr
 Updates are keyed by `(manager, packageFile, depName)` so a version bump on the same dep shows up once under `changed` rather than twice as `removed + added`. Compared per identity: `newValue`, `newVersion`, `updateType`, `branchName`, `groupName`, `schedule`.
 
 Useful when iterating on a config to see exactly what each tweak did.
+
+## `resolve_config_diff`
+
+Offline structural diff between two **fully-resolved** configs — the `before` and `after` of a config refactor. The resolve-level counterpart to [`dry_run_diff`](#dry_run_diff): where `dry_run_diff` shows how the *proposed PRs* change, this shows how the *effective settings* change. It answers "does the new config produce the same Renovate behaviour as the old one, modulo the intended changes?" without running Renovate — so it stays useful even when datasource lookups would fail (in a sandboxed/offline environment `dry_run` reports zero updates and `dry_run_diff` collapses to a vacuous 0-vs-0).
+
+Each side accepts `repoPath` (locates the repo's config via the same discovery order as [`read_config`](#read_config)) **or** `configContent` (an inline config object). If both are provided for a side, `configContent` takes precedence (consistent with [`resolve_config`](#resolve_config)). Both sides are expanded with [`resolve_config`](#resolve_config)'s preset expansion + faithful worker-thread merge before being compared.
+
+The shared `externalPresets` / `endpoint` / `platform` knobs mirror [`resolve_config`](#resolve_config) and apply to **both** sides — a refactor is diffed under one resolution context. Default is fully offline (no network I/O).
+
+**Diff semantics (top-level keys only):**
+
+- **Non-array keys** → deep-compared; a difference is reported in `fieldChanges` as `{ key, before, after }` carrying the full values. A nested array inside an object is part of that object's value and surfaces as a whole-field change.
+- **Array-valued keys** (`packageRules`, `customManagers`, `matchManagers`, `addLabels`, …) → order-insensitive **set diff**. Members are JSON-normalized (recursive key-sort), so a reordered array reads as no change and reordered keys within a member compare equal. Members only in `before` are `removed`, only in `after` are `added`; there is **no pairing**, so a slightly-tweaked rule shows as one `removed` + one `added`. Because it is a *set* diff, duplicate members (entries with the same normalized form) collapse to one — if an array carries intentional duplicate entries, the diff may undercount changes to them.
+
+Returns `summary` (`fieldsChanged`, `arraysChanged`, `arrayItemsAdded`, `arrayItemsRemoved`), `fieldChanges`, `arrayChanges` (keyed by config key), a human-readable `text` rendering, and a `resolution` block carrying each side's `mergeQuality`, `presetsUnresolved`, and `warnings`. When either side fell back to the approximate `"preview"` merge or has unresolved presets, the `text` is prefixed with a one-line advisory so the diff is never read as authoritative when it isn't.
 
 ## `migrate_config`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { registerValidateConfig } from "./tools/validateConfig.js";
 import { registerLintConfig } from "./tools/lintConfig.js";
 import { registerResolveConfig } from "./tools/resolveConfig.js";
 import { registerExplainConfig } from "./tools/explainConfig.js";
+import { registerResolveConfigDiff } from "./tools/resolveConfigDiff.js";
 import { registerPreviewCustomManager } from "./tools/previewCustomManager.js";
 import { registerDryRun } from "./tools/dryRun.js";
 import { registerDryRunDiff } from "./tools/dryRunDiff.js";
@@ -35,13 +36,14 @@ const BASE_INSTRUCTIONS = [
   "  1. read_config            — inspect the current config in a repo",
   "  2. resolve_config         — expand built-in presets to see what a config actually becomes (offline)",
   "  3. explain_config         — inverse of resolve_config: trace which preset set each field (offline)",
-  "  4. preview_custom_manager — iterate on a regex-based customManagers entry; shows file/line hits and extracted deps",
-  "  5. validate_config        — check a proposed config against Renovate's schema",
-  "  6. lint_config            — semantic lint pass: catches Renovate-specific footguns schema validation misses (e.g. malformed /…/ regex patterns)",
-  "  7. dry_run                — preview what Renovate would actually do (no PRs)",
-  "  8. dry_run_diff           — semantic diff between two dry_run reports (added/removed/changed updates)",
-  "  9. migrate_config         — apply Renovate's built-in migrations (deprecated keys → current schema) and return the migrated config",
-  " 10. write_config           — save the agreed-upon config (validates first)",
+  "  4. resolve_config_diff    — offline structural diff of two resolved configs (changed fields + array/packageRules set diffs); use this over dry_run_diff for config refactors, especially when registries are unreachable",
+  "  5. preview_custom_manager — iterate on a regex-based customManagers entry; shows file/line hits and extracted deps",
+  "  6. validate_config        — check a proposed config against Renovate's schema",
+  "  7. lint_config            — semantic lint pass: catches Renovate-specific footguns schema validation misses (e.g. malformed /…/ regex patterns)",
+  "  8. dry_run                — preview what Renovate would actually do (no PRs)",
+  "  9. dry_run_diff           — semantic diff between two dry_run reports (added/removed/changed updates)",
+  " 10. migrate_config         — apply Renovate's built-in migrations (deprecated keys → current schema) and return the migrated config",
+  " 11. write_config           — save the agreed-upon config (validates first)",
   "",
   "Before the first repo-touching tool call in a session (read_config, resolve_config, dry_run, write_config, …), call check_setup with the same repoPath. It surfaces token / endpoint / connectivity problems up front (e.g. \"set GITHUB_TOKEN or github-actions deps will be skipped\") instead of waiting for dry_run to fail. Skip if the user has already confirmed setup or is doing offline-only work that doesn't depend on git origin or registries.",
   "If any tool fails unexpectedly, call check_setup to diagnose CLI availability.",
@@ -71,6 +73,7 @@ registerCheckSetup(server);
 registerReadConfig(server);
 registerResolveConfig(server);
 registerExplainConfig(server);
+registerResolveConfigDiff(server);
 registerPreviewCustomManager(server);
 registerValidateConfig(server);
 registerLintConfig(server);

--- a/src/lib/resolveConfigDiff.ts
+++ b/src/lib/resolveConfigDiff.ts
@@ -1,0 +1,190 @@
+/**
+ * Pure structural diff over two *resolved* Renovate configs (the output of
+ * `resolve_config` — preset-expanded and merged). This is the resolve-level
+ * counterpart to `dryRunDiff.ts`: it answers "did this config refactor change
+ * the effective settings only in the ways I intended?" without running
+ * Renovate, so it works offline even when datasource lookups would fail.
+ *
+ * Two diff modes by key shape:
+ *   - Array-valued top-level keys (`packageRules`, `customManagers`,
+ *     `matchManagers`, `addLabels`, …) → order-insensitive *set* diff. Members
+ *     are normalized with `stableStringify` (recursive sort-keys) and compared
+ *     as a set, so a reordered array reads as no change and a tweaked rule
+ *     reads as one removed + one added (no pairing). Mirrors the throwaway
+ *     Python script this tool replaces.
+ *   - Everything else → deep-compare via `stableStringify` equality; a
+ *     difference emits the full before/after values.
+ *
+ * Only TOP-LEVEL keys are walked. Arrays nested inside an object are part of
+ * that object's deep-compare and surface as a whole-field change.
+ */
+
+export interface ResolveConfigFieldChange {
+  key: string;
+  before: unknown;
+  after: unknown;
+}
+
+export interface ResolveConfigArrayChange {
+  added: unknown[];
+  removed: unknown[];
+}
+
+export interface ResolveConfigDiffSummary {
+  fieldsChanged: number;
+  arraysChanged: number;
+  arrayItemsAdded: number;
+  arrayItemsRemoved: number;
+}
+
+export interface ResolveConfigDiff {
+  summary: ResolveConfigDiffSummary;
+  fieldChanges: ResolveConfigFieldChange[];
+  arrayChanges: Record<string, ResolveConfigArrayChange>;
+  text: string;
+}
+
+/**
+ * Deterministic JSON serialization with object keys sorted recursively, so two
+ * structurally-equal values produce byte-identical strings regardless of key
+ * insertion order. `JSON.stringify` alone preserves insertion order, which
+ * would make `{a,b}` and `{b,a}` compare unequal. Arrays keep their order
+ * (callers that want order-insensitivity sort the normalized members).
+ */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(sortValue(value));
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortValue);
+  }
+  if (value && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(obj).sort()) {
+      out[key] = sortValue(obj[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function diffArrayKey(before: unknown[], after: unknown[]): ResolveConfigArrayChange {
+  const beforeNorm = new Map<string, unknown>();
+  for (const item of before) beforeNorm.set(stableStringify(item), item);
+  const afterNorm = new Map<string, unknown>();
+  for (const item of after) afterNorm.set(stableStringify(item), item);
+
+  const removed: unknown[] = [];
+  for (const [norm, item] of beforeNorm) {
+    if (!afterNorm.has(norm)) removed.push(item);
+  }
+  const added: unknown[] = [];
+  for (const [norm, item] of afterNorm) {
+    if (!beforeNorm.has(norm)) added.push(item);
+  }
+
+  // Deterministic output regardless of source ordering.
+  removed.sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)));
+  added.sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)));
+  return { added, removed };
+}
+
+export function diffResolvedConfigs(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): ResolveConfigDiff {
+  const keys = Array.from(new Set([...Object.keys(before), ...Object.keys(after)])).sort();
+
+  const fieldChanges: ResolveConfigFieldChange[] = [];
+  const arrayChanges: Record<string, ResolveConfigArrayChange> = {};
+
+  for (const key of keys) {
+    const hasBefore = Object.prototype.hasOwnProperty.call(before, key);
+    const hasAfter = Object.prototype.hasOwnProperty.call(after, key);
+    const beforeVal = before[key];
+    const afterVal = after[key];
+
+    const beforeIsArray = Array.isArray(beforeVal);
+    const afterIsArray = Array.isArray(afterVal);
+
+    // Treat a key as "array-shaped" when it is an array on at least one side
+    // and never a non-array object on the other (so we don't set-diff an
+    // array against a scalar/object — that's a real type change).
+    if (
+      (beforeIsArray || afterIsArray) &&
+      (!hasBefore || beforeIsArray) &&
+      (!hasAfter || afterIsArray)
+    ) {
+      const change = diffArrayKey(
+        beforeIsArray ? (beforeVal as unknown[]) : [],
+        afterIsArray ? (afterVal as unknown[]) : [],
+      );
+      if (change.added.length > 0 || change.removed.length > 0) {
+        arrayChanges[key] = change;
+      }
+      continue;
+    }
+
+    if (!hasBefore || !hasAfter || stableStringify(beforeVal) !== stableStringify(afterVal)) {
+      fieldChanges.push({
+        key,
+        before: hasBefore ? beforeVal : undefined,
+        after: hasAfter ? afterVal : undefined,
+      });
+    }
+  }
+
+  const summary: ResolveConfigDiffSummary = {
+    fieldsChanged: fieldChanges.length,
+    arraysChanged: Object.keys(arrayChanges).length,
+    arrayItemsAdded: Object.values(arrayChanges).reduce((n, c) => n + c.added.length, 0),
+    arrayItemsRemoved: Object.values(arrayChanges).reduce((n, c) => n + c.removed.length, 0),
+  };
+
+  return {
+    summary,
+    fieldChanges,
+    arrayChanges,
+    text: renderText(summary, fieldChanges, arrayChanges),
+  };
+}
+
+function renderText(
+  summary: ResolveConfigDiffSummary,
+  fieldChanges: ResolveConfigFieldChange[],
+  arrayChanges: Record<string, ResolveConfigArrayChange>,
+): string {
+  if (summary.fieldsChanged === 0 && summary.arraysChanged === 0) {
+    return "No differences between the two resolved configs.";
+  }
+
+  const lines: string[] = [];
+  lines.push(
+    `${summary.fieldsChanged} field${summary.fieldsChanged === 1 ? "" : "s"} changed · ` +
+      `${summary.arraysChanged} array key${summary.arraysChanged === 1 ? "" : "s"} changed ` +
+      `(+${summary.arrayItemsAdded} / -${summary.arrayItemsRemoved})`,
+  );
+
+  if (fieldChanges.length > 0) {
+    lines.push("", "Changed fields:");
+    for (const fc of fieldChanges) {
+      lines.push(`  ${fc.key}: OLD=${formatValue(fc.before)}  NEW=${formatValue(fc.after)}`);
+    }
+  }
+
+  for (const key of Object.keys(arrayChanges).sort()) {
+    const change = arrayChanges[key]!;
+    lines.push("", `${key}:`);
+    for (const item of change.removed) lines.push(`  - ${stableStringify(item)}`);
+    for (const item of change.added) lines.push(`  + ${stableStringify(item)}`);
+  }
+
+  return lines.join("\n");
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined) return "(unset)";
+  return stableStringify(value);
+}

--- a/src/tools/resolveConfigDiff.ts
+++ b/src/tools/resolveConfigDiff.ts
@@ -1,0 +1,135 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { locateConfig } from "../lib/configLocations.js";
+import { resolveConfig, type ResolveResult } from "../lib/presetResolver.js";
+import { diffResolvedConfigs } from "../lib/resolveConfigDiff.js";
+import { configRecord, endpointString, pathString } from "../lib/inputLimits.js";
+
+const sideSchema = z
+  .object({
+    repoPath: pathString(
+      "Absolute path to the repository root. The tool locates the repo's renovate config automatically.",
+    ).optional(),
+    configContent: configRecord(
+      "Inline config object to resolve — use instead of repoPath.",
+    ).optional(),
+  })
+  .describe("One side of the diff: pass repoPath OR configContent.");
+
+type Side = z.infer<typeof sideSchema>;
+
+async function resolveSide(
+  label: "before" | "after",
+  input: Side,
+  options: Parameters<typeof resolveConfig>[1],
+): Promise<
+  | { ok: true; result: ResolveResult; path?: string }
+  | { ok: false; error: string }
+> {
+  if (!input.repoPath && !input.configContent) {
+    return { ok: false, error: `Provide either repoPath or configContent for ${label}.` };
+  }
+
+  let source: Record<string, unknown>;
+  let sourcePath: string | undefined;
+  if (input.configContent) {
+    source = input.configContent;
+  } else {
+    const located = await locateConfig(input.repoPath!);
+    if (!located) {
+      return { ok: false, error: `No Renovate configuration found in ${input.repoPath} (${label}).` };
+    }
+    source = located.config;
+    sourcePath = located.relPath;
+  }
+
+  const result = await resolveConfig(source, options);
+  return { ok: true, result, path: sourcePath };
+}
+
+export function registerResolveConfigDiff(server: McpServer): void {
+  server.registerTool(
+    "resolve_config_diff",
+    {
+      title: "Diff two resolved Renovate configs",
+      description:
+        "Compute a structural diff between two *fully-resolved* Renovate configs — the `before` and `after` of a config refactor — entirely offline. This is the resolve-level counterpart to `dry_run_diff`: where `dry_run_diff` shows how the *proposed PRs* change (and collapses to a vacuous 0-vs-0 when the environment can't reach registries), this answers \"does the new config produce the same effective settings as the old one, modulo the intended changes?\". Each side accepts `repoPath` (locates the repo's config) OR `configContent` (an inline config object); both sides are resolved with `resolve_config`'s preset expansion + faithful merge. Non-array top-level keys are deep-compared and reported with before/after values; array-valued top-level keys (`packageRules`, `customManagers`, `matchManagers`, …) get an order-insensitive set diff (members only in `before` are `removed`, only in `after` are `added` — a tweaked rule shows as one of each). Shared `externalPresets` / `endpoint` / `platform` knobs apply to both sides. Returns a structured diff (`summary`, `fieldChanges`, `arrayChanges`) plus a human-readable `text` rendering and per-side `resolution` metadata (`mergeQuality`, `presetsUnresolved`, `warnings`).",
+      inputSchema: {
+        before: sideSchema,
+        after: sideSchema,
+        externalPresets: z
+          .boolean()
+          .optional()
+          .describe(
+            "When true, fetch external presets (github>, gitlab>) over HTTPS for BOTH sides. Credentials come from RENOVATE_TOKEN (preferred) or GITHUB_TOKEN / GITLAB_TOKEN as platform-specific fallbacks, set on the MCP server process. Default false (fully offline).",
+          ),
+        endpoint: endpointString(
+          "API base URL for github>/gitlab> fetches, applied to both sides. Use for GitHub Enterprise (e.g. https://ghe.example.com/api/v3) or self-hosted GitLab (e.g. https://gitlab.example.com/api/v4).",
+        ).optional(),
+        platform: z
+          .enum(["github", "gitlab"])
+          .optional()
+          .describe(
+            "Platform flavour of `endpoint`, applied to both sides. When set, `local>owner/repo` presets are fetched as if they were `<platform>>owner/repo`.",
+          ),
+      },
+    },
+    async ({ before, after, externalPresets, endpoint, platform }) => {
+      const options = { fetchExternal: externalPresets ?? false, endpoint, platform };
+      const [beforeRes, afterRes] = await Promise.all([
+        resolveSide("before", before, options),
+        resolveSide("after", after, options),
+      ]);
+
+      if (!beforeRes.ok) {
+        return { isError: true, content: [{ type: "text", text: beforeRes.error }] };
+      }
+      if (!afterRes.ok) {
+        return { isError: true, content: [{ type: "text", text: afterRes.error }] };
+      }
+
+      const diff = diffResolvedConfigs(beforeRes.result.resolved, afterRes.result.resolved);
+
+      const resolution = {
+        before: sideMeta(beforeRes.result, beforeRes.path),
+        after: sideMeta(afterRes.result, afterRes.path),
+      };
+
+      const advisory = degradedAdvisory(beforeRes.result, afterRes.result);
+      const text = advisory ? `${advisory}\n\n${diff.text}` : diff.text;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ ...diff, text, resolution }, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}
+
+function sideMeta(result: ResolveResult, path?: string) {
+  return {
+    ...(path ? { path } : {}),
+    mergeQuality: result.mergeQuality,
+    presetsUnresolved: result.presetsUnresolved,
+    warnings: result.warnings,
+  };
+}
+
+function degradedAdvisory(before: ResolveResult, after: ResolveResult): string | null {
+  const notes: string[] = [];
+  if (before.mergeQuality === "preview" || after.mergeQuality === "preview") {
+    notes.push(
+      "one or both sides used the approximate in-process merge (mergeQuality: \"preview\") — the diff may not be authoritative",
+    );
+  }
+  if (before.presetsUnresolved.length > 0 || after.presetsUnresolved.length > 0) {
+    notes.push(
+      "one or both sides have unresolved presets — fields they would contribute are absent from this diff (see resolution.presetsUnresolved)",
+    );
+  }
+  return notes.length > 0 ? `⚠ ${notes.join("; ")}.` : null;
+}

--- a/test/integration/mcpServer.test.ts
+++ b/test/integration/mcpServer.test.ts
@@ -11,7 +11,7 @@ afterEach(async () => {
 });
 
 describe("MCP server stdio handshake", () => {
-  it("lists all twelve tools with expected names", async () => {
+  it("lists all thirteen tools with expected names", async () => {
     session = await startServer();
     const res = await session.request<{ tools: Array<{ name: string }> }>("tools/list");
     const names = (res.result?.tools ?? []).map((t) => t.name).sort();
@@ -26,6 +26,7 @@ describe("MCP server stdio handshake", () => {
       "preview_custom_manager",
       "read_config",
       "resolve_config",
+      "resolve_config_diff",
       "validate_config",
       "write_config",
     ]);

--- a/test/integration/resolveConfigDiff.test.ts
+++ b/test/integration/resolveConfigDiff.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { startServer, type McpSession } from "../helpers/mcpSession.js";
+
+let session: McpSession;
+let scratch: string;
+
+beforeEach(async () => {
+  scratch = await mkdtemp(path.join(tmpdir(), `rmcp-rcd-${process.pid}-`));
+});
+
+afterEach(async () => {
+  if (session) await session.close();
+  await rm(scratch, { recursive: true, force: true });
+});
+
+type CallResult = {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+};
+
+async function diff(before: unknown, after: unknown): Promise<CallResult> {
+  const res = await session.request<CallResult>("tools/call", {
+    name: "resolve_config_diff",
+    arguments: { before, after },
+  });
+  return res.result!;
+}
+
+describe("resolve_config_diff", () => {
+  it("diffs two inline configs differing in a scalar", async () => {
+    session = await startServer({});
+    const result = await diff(
+      { configContent: { prHourlyLimit: 2 } },
+      { configContent: { prHourlyLimit: 0 } },
+    );
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(result.content[0]!.text) as {
+      summary: { fieldsChanged: number };
+      fieldChanges: Array<{ key: string }>;
+    };
+    expect(body.summary.fieldsChanged).toBe(1);
+    expect(body.fieldChanges[0]!.key).toBe("prHourlyLimit");
+  });
+
+  it("set-diffs packageRules between two inline configs", async () => {
+    session = await startServer({});
+    const result = await diff(
+      { configContent: { packageRules: [{ matchManagers: ["npm"], automerge: true }] } },
+      {
+        configContent: {
+          packageRules: [
+            { matchManagers: ["npm"], automerge: true },
+            { matchManagers: ["docker"], automerge: false },
+          ],
+        },
+      },
+    );
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(result.content[0]!.text) as {
+      arrayChanges: { packageRules?: { added: unknown[]; removed: unknown[] } };
+    };
+    expect(body.arrayChanges.packageRules!.added).toHaveLength(1);
+    expect(body.arrayChanges.packageRules!.removed).toHaveLength(0);
+  });
+
+  it("resolves built-in extends faithfully and reports per-side mergeQuality", async () => {
+    session = await startServer({});
+    const result = await diff(
+      { configContent: { extends: ["config:recommended"] } },
+      { configContent: { extends: ["config:recommended"], prHourlyLimit: 0 } },
+    );
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(result.content[0]!.text) as {
+      summary: { fieldsChanged: number };
+      resolution: { before: { mergeQuality: string }; after: { mergeQuality: string } };
+    };
+    expect(body.resolution.before.mergeQuality).toBe("faithful");
+    expect(body.resolution.after.mergeQuality).toBe("faithful");
+    // Only prHourlyLimit should differ; config:recommended is identical on both sides.
+    expect(body.summary.fieldsChanged).toBe(1);
+  });
+
+  it("resolves a side from repoPath (locates renovate.json) and diffs against inline content", async () => {
+    await writeFile(
+      path.join(scratch, "renovate.json"),
+      JSON.stringify({ prHourlyLimit: 2 }),
+    );
+    session = await startServer({});
+    const result = await diff(
+      { repoPath: scratch },
+      { configContent: { prHourlyLimit: 0 } },
+    );
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(result.content[0]!.text) as {
+      summary: { fieldsChanged: number };
+      resolution: { before: { path?: string } };
+    };
+    expect(body.summary.fieldsChanged).toBe(1);
+    expect(body.resolution.before.path).toBe("renovate.json");
+  });
+
+  it("prefixes the text with a ⚠ advisory when a side has unresolved presets", async () => {
+    session = await startServer({});
+    const result = await diff(
+      { configContent: { extends: ["bitbucket>owner/repo"] } },
+      { configContent: { prHourlyLimit: 0 } },
+    );
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(result.content[0]!.text) as {
+      text: string;
+      resolution: { before: { presetsUnresolved: unknown[] } };
+    };
+    expect(body.resolution.before.presetsUnresolved.length).toBeGreaterThan(0);
+    expect(body.text.startsWith("⚠")).toBe(true);
+    expect(body.text).toMatch(/unresolved presets/);
+  });
+
+  it("returns isError when a side has neither repoPath nor configContent", async () => {
+    session = await startServer({});
+    const result = await diff({}, { configContent: { prHourlyLimit: 0 } });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/Provide either repoPath or configContent for before/);
+  });
+
+  it("advertises the tool in the server instructions", async () => {
+    session = await startServer({});
+    expect(session.instructions).toContain("resolve_config_diff");
+  });
+});

--- a/test/unit/resolveConfigDiff.test.ts
+++ b/test/unit/resolveConfigDiff.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { diffResolvedConfigs, stableStringify } from "../../src/lib/resolveConfigDiff.js";
+
+describe("stableStringify", () => {
+  it("is insensitive to object key order", () => {
+    expect(stableStringify({ a: 1, b: 2 })).toBe(stableStringify({ b: 2, a: 1 }));
+  });
+
+  it("sorts keys recursively but preserves array order", () => {
+    expect(stableStringify({ x: { b: 1, a: 2 }, list: [3, 1, 2] })).toBe(
+      '{"list":[3,1,2],"x":{"a":2,"b":1}}',
+    );
+  });
+});
+
+describe("diffResolvedConfigs", () => {
+  it("reports no differences for identical configs", () => {
+    const diff = diffResolvedConfigs({ a: 1, b: { c: 2 } }, { b: { c: 2 }, a: 1 });
+    expect(diff.summary).toEqual({
+      fieldsChanged: 0,
+      arraysChanged: 0,
+      arrayItemsAdded: 0,
+      arrayItemsRemoved: 0,
+    });
+    expect(diff.text).toMatch(/No differences/);
+  });
+
+  it("detects a scalar change", () => {
+    const diff = diffResolvedConfigs({ prHourlyLimit: 2 }, { prHourlyLimit: 0 });
+    expect(diff.summary.fieldsChanged).toBe(1);
+    expect(diff.fieldChanges).toEqual([{ key: "prHourlyLimit", before: 2, after: 0 }]);
+  });
+
+  it("detects a nested-object change as a whole-field change", () => {
+    const diff = diffResolvedConfigs(
+      { lockFileMaintenance: { enabled: false } },
+      { lockFileMaintenance: { enabled: true } },
+    );
+    expect(diff.summary.fieldsChanged).toBe(1);
+    expect(diff.fieldChanges[0]).toEqual({
+      key: "lockFileMaintenance",
+      before: { enabled: false },
+      after: { enabled: true },
+    });
+  });
+
+  it("reports a key present on only one side with undefined on the missing side", () => {
+    const added = diffResolvedConfigs({}, { semanticCommits: "enabled" });
+    expect(added.fieldChanges).toEqual([
+      { key: "semanticCommits", before: undefined, after: "enabled" },
+    ]);
+    const removed = diffResolvedConfigs({ semanticCommits: "enabled" }, {});
+    expect(removed.fieldChanges).toEqual([
+      { key: "semanticCommits", before: "enabled", after: undefined },
+    ]);
+  });
+
+  it("set-diffs packageRules: removed, added, and a tweaked rule as one of each", () => {
+    const before = {
+      packageRules: [
+        { matchUpdateTypes: ["minor", "patch"], automerge: true },
+        { matchDepNames: ["left-pad"], enabled: false },
+      ],
+    };
+    const after = {
+      packageRules: [
+        { matchUpdateTypes: ["minor", "patch"], automerge: false }, // tweaked
+        { groupName: "all", matchPackageNames: ["/foo/"] }, // added
+      ],
+    };
+    const diff = diffResolvedConfigs(before, after);
+    expect(diff.summary.arraysChanged).toBe(1);
+    // tweaked rule + removed enabled:false rule
+    expect(diff.arrayChanges.packageRules!.removed).toHaveLength(2);
+    // tweaked rule (new form) + brand-new group rule
+    expect(diff.arrayChanges.packageRules!.added).toHaveLength(2);
+    expect(diff.summary.arrayItemsRemoved).toBe(2);
+    expect(diff.summary.arrayItemsAdded).toBe(2);
+  });
+
+  it("treats a reordered array as no change", () => {
+    const before = { packageRules: [{ a: 1 }, { b: 2 }] };
+    const after = { packageRules: [{ b: 2 }, { a: 1 }] };
+    const diff = diffResolvedConfigs(before, after);
+    expect(diff.summary.arraysChanged).toBe(0);
+  });
+
+  it("treats array members with reordered keys as equal", () => {
+    const before = { packageRules: [{ matchManagers: ["npm"], automerge: true }] };
+    const after = { packageRules: [{ automerge: true, matchManagers: ["npm"] }] };
+    const diff = diffResolvedConfigs(before, after);
+    expect(diff.summary.arraysChanged).toBe(0);
+  });
+
+  it("generalizes the set-diff to any top-level array key", () => {
+    const diff = diffResolvedConfigs(
+      { addLabels: ["deps"] },
+      { addLabels: ["deps", "renovate"] },
+    );
+    expect(diff.arrayChanges.addLabels).toEqual({ added: ["renovate"], removed: [] });
+    expect(diff.summary.arraysChanged).toBe(1);
+  });
+
+  it("set-diffs a key that is an array on only one side", () => {
+    const diff = diffResolvedConfigs({}, { ignorePaths: ["dist/**"] });
+    expect(diff.arrayChanges.ignorePaths).toEqual({ added: ["dist/**"], removed: [] });
+  });
+
+  it("treats array-vs-non-array as a field change, not a set diff", () => {
+    const diff = diffResolvedConfigs({ foo: [1, 2] }, { foo: "bar" });
+    expect(diff.summary.arraysChanged).toBe(0);
+    expect(diff.fieldChanges).toEqual([{ key: "foo", before: [1, 2], after: "bar" }]);
+  });
+
+  it("renders a text body with field and array sections", () => {
+    const diff = diffResolvedConfigs(
+      { prHourlyLimit: 2, packageRules: [{ a: 1 }] },
+      { prHourlyLimit: 0, packageRules: [{ a: 1 }, { b: 2 }] },
+    );
+    expect(diff.text).toContain("Changed fields:");
+    expect(diff.text).toContain("prHourlyLimit: OLD=2  NEW=0");
+    expect(diff.text).toContain("packageRules:");
+    expect(diff.text).toContain('+ {"b":2}');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a thirteenth tool, **`resolve_config_diff`** — the offline, resolve-level counterpart to `dry_run_diff`.

Where `dry_run_diff` shows how the *proposed PRs* change (and collapses to a vacuous 0-vs-0 when the environment can't reach registries / authenticate datasource lookups), `resolve_config_diff` shows how the *effective settings* change. It answers the real question during a config **refactor**: *"does the new config produce the same Renovate behaviour as the old one, modulo the intended changes?"* — entirely offline.

It resolves a `before` and `after` config (each `repoPath` or `configContent`) through the existing preset-expansion + faithful worker-thread merge, then diffs the two resolved objects:

- **Non-array top-level keys** → deep-compared, reported in `fieldChanges` with full before/after values.
- **Array keys** (`packageRules`, `customManagers`, `matchManagers`, `addLabels`, …) → order-insensitive **set diff** (members only-in-before are `removed`, only-in-after are `added`; no pairing, so a tweaked rule shows as one of each).

Returns `summary`, `fieldChanges`, `arrayChanges`, a human-readable `text`, and per-side `resolution` metadata (`mergeQuality`, `presetsUnresolved`, `warnings`) — with a `⚠` advisory when either side degraded to preview merge or had unresolved presets.

This generalizes a throwaway Python script (resolve both, set-diff the resolved objects) into a first-class, network-independent MCP tool.

## Architecture

No new `renovate` import in the main process, no CLI shell-out, fully offline by default — all invariants inherited by composing the existing `resolveConfig` resolver. No new ADR needed.

## Changes

- **New:** `src/lib/resolveConfigDiff.ts` (pure logic), `src/tools/resolveConfigDiff.ts` (registration)
- **Wiring:** `src/index.ts` (register + workflow list)
- **Docs:** `README.md`, `docs/tools.md`, `CLAUDE.md` (twelve → thirteen tools)
- **Tests:** `test/unit/resolveConfigDiff.test.ts`, `test/integration/resolveConfigDiff.test.ts`; updated `test/integration/mcpServer.test.ts` tool-count assertion

## Verification

`npm run typecheck` clean · `npm run build` clean · full suite **674 passing** (42 new).

> CI was skipped on the commit (`[skip ci]`) per request — re-run via the Actions tab or an empty commit if checks are wanted before merge.