### PR TITLE
ci: skip post-merge build-test re-run on main, cancel superseded PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,42 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded PR runs; never cancel the post-merge run on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  # Skip the post-merge re-run on main when the commit already arrived via a
+  # merged PR — `build-test` is a REQUIRED check, so it already ran (and passed)
+  # on that PR. Direct pushes to main still run. This only affects push-to-main;
+  # PR behavior (and the ci-required-bypass companion) is untouched.
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "push" ] || [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          prs=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq 'length')
+          if [ "$prs" -gt 0 ]; then
+            echo "From a merged PR — already validated; skipping main re-run."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   build-test:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Why

Reduce wasted CI compute. Public repo (no free-minute saving), but the `build-test` matrix includes a slow macOS leg that re-ran needlessly after every PR merge.

## What

- **Skip-main-if-PR-was-green gate** (`gate` job): `build-test` is a **required** status check, so it already ran (and passed) on the PR. On a push to `main` from a merged PR, skip the post-merge re-run. Direct pushes to `main` still run it.
- **Concurrency cancellation** for superseded PR runs (also de-stacks the slow macOS leg when several commits land on a PR quickly).

## Untouched on purpose

- PR-side behavior and the `ci-required-bypass.yml` companion (required-check plumbing) are unchanged — the gate only affects push-to-`main`.
- `nightly-real-renovate.yml` (deliberate upstream-drift cron), `dependency-review.yml`, `claude.yml`, `publish.yml`, `release.yaml`.
